### PR TITLE
Exporting payload validation functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "did-jwt-vc",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Create and verify W3C Verifiable Credentials and Presentations in JWT format",
   "main": "lib/index.js",
   "umd:main": "lib/index.umd.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,7 @@ export async function createPresentation(
   })
 }
 
-function validateVerifiableCredentialAttributes(
+export function validateVerifiableCredentialAttributes(
   payload: VerifiableCredentialPayload
 ): void {
   validators.validateContext(payload.vc['@context'])
@@ -46,7 +46,7 @@ function validateVerifiableCredentialAttributes(
   if (payload.exp) validators.validateTimestamp(payload.exp)
 }
 
-function validatePresentationAttributes(payload: PresentationPayload): void {
+export function validatePresentationAttributes(payload: PresentationPayload): void {
   validators.validateContext(payload.vp['@context'])
   validators.validateType(payload.vp.type)
   if (payload.vp.verifiableCredential.length < 1) {


### PR DESCRIPTION
This is needed when trying to determine the type of JWT without verifying the signature multiple times.