### PR TITLE
feat: remove explicit declaration of the nullable `credentialStatus`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -13,7 +13,6 @@ export interface VC {
   '@context': string[]
   type: string[]
   credentialSubject: CredentialSubject
-  credentialStatus?: CredentialStatus
 }
 
 export interface VerifiableCredentialPayload {


### PR DESCRIPTION
it is already covered in the type extension
and it is not specific only to VCs
it could also be used in presentations