### PR TITLE
[feat] Add methods to handle W3C Credential format

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,7 @@
+{
+	"plugins": [
+		[
+			"@babel/plugin-proposal-optional-chaining"
+		]
+	]
+}

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Specify a `payload` matching the `CredentialPayload` or `JwtCredentialPayload` i
 with the previously configured `issuer` using the `createVerifiableCredentialJwt` function:
 
 ```typescript
-import { VerifiableCredentialPayload, createVerifiableCredential } from 'did-jwt-vc'
+import { JwtCredentialPayload, createVerifiableCredentialJwt } from 'did-jwt-vc'
 
 const vcPayload: JwtCredentialPayload = {
   sub: 'did:ethr:0x435df3eda57154cf8cf7926079881f2912f54db4',
@@ -64,9 +64,9 @@ be presented in the `vp.verifiableCredential` array. Create a JWT by signing it 
 using the `createVerifiablePresentationJwt` function:
 
 ```typescript
-import { PresentationPayload, createPresentation } from 'did-jwt-vc'
+import { JwtPresentationPayload, createVerifiablePresentationJwt } from 'did-jwt-vc'
 
-const vpPayload: PresentationPayload = {
+const vpPayload: JwtPresentationPayload = {
   vp: {
     '@context': ['https://www.w3.org/2018/credentials/v1'],
     type: ['VerifiablePresentation'],
@@ -74,7 +74,7 @@ const vpPayload: PresentationPayload = {
   }
 }
 
-const vpJwt = await createPresentation(vpPayload, issuer)
+const vpJwt = await createVerifiablePresentationJwt(vpPayload, issuer)
 console.log(vpJwt)
 // eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE1ODI1NDc...JNMUzZ6naacuWNGdZGuU0ZDwmgpUMUqIzMqFFRmge0R8QA
 ```

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # did-jwt-vc
-
 Create and verify W3C Verifiable Credentials and Presentations in JWT format
 
 ## Installation
-
 ```
 npm install did-jwt-vc
 ```
@@ -28,16 +26,18 @@ const issuer: Issuer = new EthrDID({
 
 The `Issuer` object must contain a `did` attribute, as well as a `signer` function to generate the signature.
 
-Currently, there is only support for `ethr-did` issuers to sign JWTs using the `ES256K-R` algorithm. Future versions of this library will enable support for alternative DID methods and signing algorithms.
+Currently, there is only support for `ethr-did` issuers to sign JWTs using the `ES256K` algorithm. Future versions of
+this library will enable support for alternative DID methods and signing algorithms.
 
 #### Creating a Verifiable Credential
 
-Specify a `payload` matching the `VerifiableCredentialPayload` interface. Create a JWT by signing it with the previously configured `issuer` using the `createVerifiableCredential` function:
+Specify a `payload` matching the `CredentialPayload` or `JwtCredentialPayload` interfaces. Create a JWT by signing it
+with the previously configured `issuer` using the `createVerifiableCredentialJwt` function:
 
 ```typescript
 import { VerifiableCredentialPayload, createVerifiableCredential } from 'did-jwt-vc'
 
-const vcPayload: VerifiableCredentialPayload = {
+const vcPayload: JwtCredentialPayload = {
   sub: 'did:ethr:0x435df3eda57154cf8cf7926079881f2912f54db4',
   nbf: 1562950282,
   vc: {
@@ -52,14 +52,16 @@ const vcPayload: VerifiableCredentialPayload = {
   }
 }
 
-const vcJwt = await createVerifiableCredential(vcPayload, issuer)
+const vcJwt = await createVerifiableCredentialJwt(vcPayload, issuer)
 console.log(vcJwt)
-// eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE1ODI1NDc1OTMsInN1YiI6ImRpZDpldGhyOjB4NDM1ZGYzZWRhNTcxNTRjZjhjZjc5MjYwNzk4ODFmMjkxMmY1NGRiNCIsIm5iZiI6MTU2Mjk1MDI4MiwidmMiOnsiQGNvbnRleHQiOlsiaHR0cHM6Ly93d3cudzMub3JnLzIwMTgvY3JlZGVudGlhbHMvdjEiXSwidHlwZSI6WyJWZXJpZmlhYmxlQ3JlZGVudGlhbCJdLCJjcmVkZW50aWFsU3ViamVjdCI6eyJkZWdyZWUiOnsidHlwZSI6IkJhY2hlbG9yRGVncmVlIiwibmFtZSI6IkJhY2NhbGF1csOpYXQgZW4gbXVzaXF1ZXMgbnVtw6lyaXF1ZXMifX19LCJpc3MiOiJkaWQ6ZXRocjoweGYxMjMyZjg0MGYzYWQ3ZDIzZmNkYWE4NGQ2YzY2ZGFjMjRlZmIxOTgifQ.ljTuUW6bcsoBQksMo5l8eFImVdOA-ew993B4ret_p9A8j2DLQ60CQmqB14NnN5XxD0d_glLRs1Myc_LBJjnuNwE
+// eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQi...0CQmqB14NnN5XxD0d_glLRs1Myc_LBJjnuNwE
 ```
 
 #### Creating a Verifiable Presentation
 
-Specify a `payload` matching the `PresentationPayload` interface, including the VC JWTs to be presented in the `vp.verifiableCredential` array. Create a JWT by signing it with the previously configured `issuer` using the `createPresentation` function:
+Specify a `payload` matching the `PresentationPayload` or `JwtPresentationPayload` interfaces, including the VC JWTs to
+be presented in the `vp.verifiableCredential` array. Create a JWT by signing it with the previously configured `issuer`
+using the `createVerifiablePresentationJwt` function:
 
 ```typescript
 import { PresentationPayload, createPresentation } from 'did-jwt-vc'
@@ -74,14 +76,16 @@ const vpPayload: PresentationPayload = {
 
 const vpJwt = await createPresentation(vpPayload, issuer)
 console.log(vpJwt)
-// eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE1ODI1NDc1OTMsInZwIjp7IkBjb250ZXh0IjpbImh0dHBzOi8vd3d3LnczLm9yZy8yMDE4L2NyZWRlbnRpYWxzL3YxIl0sInR5cGUiOlsiVmVyaWZpYWJsZVByZXNlbnRhdGlvbiJdLCJ2ZXJpZmlhYmxlQ3JlZGVudGlhbCI6WyJleUowZVhBaU9pSktWMVFpTENKaGJHY2lPaUpGVXpJMU5rc3RVaUo5LmV5SnBZWFFpT2pFMU9ESTFORGMxT1RNc0luTjFZaUk2SW1ScFpEcGxkR2h5T2pCNE5ETTFaR1l6WldSaE5UY3hOVFJqWmpoalpqYzVNall3TnprNE9ERm1Namt4TW1ZMU5HUmlOQ0lzSW01aVppSTZNVFUyTWprMU1ESTRNaXdpZG1NaU9uc2lRR052Ym5SbGVIUWlPbHNpYUhSMGNITTZMeTkzZDNjdWR6TXViM0puTHpJd01UZ3ZZM0psWkdWdWRHbGhiSE12ZGpFaVhTd2lkSGx3WlNJNld5SldaWEpwWm1saFlteGxRM0psWkdWdWRHbGhiQ0pkTENKamNtVmtaVzUwYVdGc1UzVmlhbVZqZENJNmV5SmtaV2R5WldVaU9uc2lkSGx3WlNJNklrSmhZMmhsYkc5eVJHVm5jbVZsSWl3aWJtRnRaU0k2SWtKaFkyTmhiR0YxY3NPcFlYUWdaVzRnYlhWemFYRjFaWE1nYm5WdHc2bHlhWEYxWlhNaWZYMTlMQ0pwYzNNaU9pSmthV1E2WlhSb2Nqb3dlR1l4TWpNeVpqZzBNR1l6WVdRM1pESXpabU5rWVdFNE5HUTJZelkyWkdGak1qUmxabUl4T1RnaWZRLmxqVHVVVzZiY3NvQlFrc01vNWw4ZUZJbVZkT0EtZXc5OTNCNHJldF9wOUE4ajJETFE2MENRbXFCMTRObk41WHhEMGRfZ2xMUnMxTXljX0xCSmpudU53RSJdfSwiaXNzIjoiZGlkOmV0aHI6MHhmMTIzMmY4NDBmM2FkN2QyM2ZjZGFhODRkNmM2NmRhYzI0ZWZiMTk4In0.cFyO-xPMdj0Hg1DaCkm30hzcVcYdnDdgyxXLZr9NAJNMUzZ6naacuWNGdZGuU0ZDwmgpUMUqIzMqFFRmge0R8QA
+// eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE1ODI1NDc...JNMUzZ6naacuWNGdZGuU0ZDwmgpUMUqIzMqFFRmge0R8QA
 ```
 
 ### Verifying JWTs
 
 #### Prerequisites
 
-Create a `Resolver` using [did-resolver](https://github.com/decentralized-identity/did-resolver) and register the [ethr-did-resolver](https://github.com/decentralized-identity/ethr-did-resolver). When verifying a JWT signed by a DID, it is necessary to resolve its DID Document to check for keys that can validate the signature.
+Create a `Resolver` using [did-resolver](https://github.com/decentralized-identity/did-resolver) and register the
+[ethr-did-resolver](https://github.com/decentralized-identity/ethr-did-resolver). When verifying a JWT signed by a DID,
+it is necessary to resolve its DID Document to check for keys that can validate the signature.
 
 ```typescript
 import { Resolver } from 'did-resolver'
@@ -106,29 +110,38 @@ const verifiedVC = await verifyCredential(vcJwt, resolver)
 console.log(verifiedVC)
 /*
 {
-  payload: {
-    iat: 1582547593,
-    sub: 'did:ethr:0x435df3eda57154cf8cf7926079881f2912f54db4',
-    nbf: 1562950282,
-    vc: { '@context': [Array], type: [Array], credentialSubject: [Object] },
-    iss: 'did:ethr:0xf1232f840f3ad7d23fcdaa84d6c66dac24efb198'
+  "payload": {
+    // the original payload of the signed credential
   },
-  doc: {
-    '@context': 'https://w3id.org/did/v1',
-    id: 'did:ethr:0xf1232f840f3ad7d23fcdaa84d6c66dac24efb198',
-    publicKey: [ [Object] ],
-    authentication: [ [Object] ]
+  "doc": {
+    // the DID document of the credential issuer (as returned by the `resolver`)
   },
-  issuer: 'did:ethr:0xf1232f840f3ad7d23fcdaa84d6c66dac24efb198',
-  signer: {
-    id: 'did:ethr:0xf1232f840f3ad7d23fcdaa84d6c66dac24efb198#owner',
-    type: 'Secp256k1VerificationKey2018',
-    owner: 'did:ethr:0xf1232f840f3ad7d23fcdaa84d6c66dac24efb198',
-    ethereumAddress: '0xf1232f840f3ad7d23fcdaa84d6c66dac24efb198'
+  "issuer": "did:ethr:0xf1232f840f3ad7d23fcdaa84d6c66dac24efb198", //the credential issuer
+  "signer": {
+    //the publicKey entry of the `doc` that has signed the credential
   },
-  jwt: 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE1ODI1NDc1OTMsInN1YiI6ImRpZDpldGhyOjB4NDM1ZGYzZWRhNTcxNTRjZjhjZjc5MjYwNzk4ODFmMjkxMmY1NGRiNCIsIm5iZiI6MTU2Mjk1MDI4MiwidmMiOnsiQGNvbnRleHQiOlsiaHR0cHM6Ly93d3cudzMub3JnLzIwMTgvY3JlZGVudGlhbHMvdjEiXSwidHlwZSI6WyJWZXJpZmlhYmxlQ3JlZGVudGlhbCJdLCJjcmVkZW50aWFsU3ViamVjdCI6eyJkZWdyZWUiOnsidHlwZSI6IkJhY2hlbG9yRGVncmVlIiwibmFtZSI6IkJhY2NhbGF1csOpYXQgZW4gbXVzaXF1ZXMgbnVtw6lyaXF1ZXMifX19LCJpc3MiOiJkaWQ6ZXRocjoweGYxMjMyZjg0MGYzYWQ3ZDIzZmNkYWE4NGQ2YzY2ZGFjMjRlZmIxOTgifQ.ljTuUW6bcsoBQksMo5l8eFImVdOA-ew993B4ret_p9A8j2DLQ60CQmqB14NnN5XxD0d_glLRs1Myc_LBJjnuNwE'
+  "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE1NjY...Sx3Y2IdWaUpatJQA", // the original credential
+  "verifiableCredential": {
+    "@context": [Array],
+    "type": [ "VerifiableCredential", "UniversityDegreeCredential" ],
+    "issuer": {
+      "id": "did:ethr:0xf1232f840f3ad7d23fcdaa84d6c66dac24efb198"
+    },
+    "issuanceDate": "2019-07-12T16:51:22.000Z",
+    "credentialSubject": {
+      "id": "did:ethr:0x435df3eda57154cf8cf7926079881f2912f54db4"
+      "degree": {
+        "type": "BachelorDegree",
+        "name": "Baccalauréat en musiques numériques"
+      },
+    },
+    "proof": {
+      "type": "JwtProof2020",
+      "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE1NjY...Sx3Y2IdWaUpatJQA"
+    }
+  }
 }
- */
+*/
 ```
 
 #### Verifying a Verifiable Presentation
@@ -143,28 +156,68 @@ console.log(verifiedVP)
 /*
 {
   payload: {
-    iat: 1582547593,
+    iat: 1568045263,
     vp: {
       '@context': [Array],
-      type: [Array],
-      verifiableCredential: [Array]
+      type: ['VerifiablePresentation'],
+      verifiableCredential: [
+        'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE1NjY5...lpNm51cqSx3Y2IdWaUpatJQA'
+      ]
     },
     iss: 'did:ethr:0xf1232f840f3ad7d23fcdaa84d6c66dac24efb198'
   },
+  
   doc: {
     '@context': 'https://w3id.org/did/v1',
     id: 'did:ethr:0xf1232f840f3ad7d23fcdaa84d6c66dac24efb198',
-    publicKey: [ [Object] ],
-    authentication: [ [Object] ]
+    publicKey: [
+      {
+        id: 'did:ethr:0xf1232f840f3ad7d23fcdaa84d6c66dac24efb198#owner',
+        type: 'Secp256k1VerificationKey2018',
+        ethereumAddress: '0xf1232f840f3ad7d23fcdaa84d6c66dac24efb198',
+        owner: 'did:ethr:0xf1232f840f3ad7d23fcdaa84d6c66dac24efb198'
+      }
+    ]
   },
+  
   issuer: 'did:ethr:0xf1232f840f3ad7d23fcdaa84d6c66dac24efb198',
+  
   signer: {
     id: 'did:ethr:0xf1232f840f3ad7d23fcdaa84d6c66dac24efb198#owner',
     type: 'Secp256k1VerificationKey2018',
-    owner: 'did:ethr:0xf1232f840f3ad7d23fcdaa84d6c66dac24efb198',
-    ethereumAddress: '0xf1232f840f3ad7d23fcdaa84d6c66dac24efb198'
+    ethereumAddress: '0xf1232f840f3ad7d23fcdaa84d6c66dac24efb198',
+    owner: 'did:ethr:0xf1232f840f3ad7d23fcdaa84d6c66dac24efb198'
   },
-  jwt: 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE1ODI1NDc1OTMsInZwIjp7IkBjb250ZXh0IjpbImh0dHBzOi8vd3d3LnczLm9yZy8yMDE4L2NyZWRlbnRpYWxzL3YxIl0sInR5cGUiOlsiVmVyaWZpYWJsZVByZXNlbnRhdGlvbiJdLCJ2ZXJpZmlhYmxlQ3JlZGVudGlhbCI6WyJleUowZVhBaU9pSktWMVFpTENKaGJHY2lPaUpGVXpJMU5rc3RVaUo5LmV5SnBZWFFpT2pFMU9ESTFORGMxT1RNc0luTjFZaUk2SW1ScFpEcGxkR2h5T2pCNE5ETTFaR1l6WldSaE5UY3hOVFJqWmpoalpqYzVNall3TnprNE9ERm1Namt4TW1ZMU5HUmlOQ0lzSW01aVppSTZNVFUyTWprMU1ESTRNaXdpZG1NaU9uc2lRR052Ym5SbGVIUWlPbHNpYUhSMGNITTZMeTkzZDNjdWR6TXViM0puTHpJd01UZ3ZZM0psWkdWdWRHbGhiSE12ZGpFaVhTd2lkSGx3WlNJNld5SldaWEpwWm1saFlteGxRM0psWkdWdWRHbGhiQ0pkTENKamNtVmtaVzUwYVdGc1UzVmlhbVZqZENJNmV5SmtaV2R5WldVaU9uc2lkSGx3WlNJNklrSmhZMmhsYkc5eVJHVm5jbVZsSWl3aWJtRnRaU0k2SWtKaFkyTmhiR0YxY3NPcFlYUWdaVzRnYlhWemFYRjFaWE1nYm5WdHc2bHlhWEYxWlhNaWZYMTlMQ0pwYzNNaU9pSmthV1E2WlhSb2Nqb3dlR1l4TWpNeVpqZzBNR1l6WVdRM1pESXpabU5rWVdFNE5HUTJZelkyWkdGak1qUmxabUl4T1RnaWZRLmxqVHVVVzZiY3NvQlFrc01vNWw4ZUZJbVZkT0EtZXc5OTNCNHJldF9wOUE4ajJETFE2MENRbXFCMTRObk41WHhEMGRfZ2xMUnMxTXljX0xCSmpudU53RSJdfSwiaXNzIjoiZGlkOmV0aHI6MHhmMTIzMmY4NDBmM2FkN2QyM2ZjZGFhODRkNmM2NmRhYzI0ZWZiMTk4In0.cFyO-xPMdj0Hg1DaCkm30hzcVcYdnDdgyxXLZr9NAJNMUzZ6naacuWNGdZGuU0ZDwmgpUMUqIzMqFFRmge0R8QA'
+
+  jwt: 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE1NjgwNDUyNjMsInZwIjp7...ViNNCvoTQ-swSHwbELW7-EGPAcHLOMiIwE',
+
+  verifiablePresentation: {
+    verifiableCredential: [
+      {
+        iat: 1566923269,
+        credentialSubject: {
+          degree: { type: 'BachelorDegree', name: 'Baccalauréat en musiques numériques' },
+          id: 'did:ethr:0x435df3eda57154cf8cf7926079881f2912f54db4'
+        },
+        issuer: { id: 'did:ethr:0xf1232f840f3ad7d23fcdaa84d6c66dac24efb198' },
+        type: ['VerifiableCredential', 'UniversityDegreeCredential'],
+        '@context': [Array],
+        issuanceDate: '2019-07-12T16:51:22.000Z',
+        proof: {
+          type: 'JwtProof2020',
+          jwt: 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE1NjY5...lpNm51cqSx3Y2IdWaUpatJQA'
+        }
+      }
+    ],
+    holder: 'did:ethr:0xf1232f840f3ad7d23fcdaa84d6c66dac24efb198',
+    type: ['VerifiablePresentation'],
+    '@context': [Array],
+    issuanceDate: '2019-09-09T16:07:43.000Z',
+    proof: {
+      type: 'JwtProof2020',
+      jwt: 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE1NjgwNDUyNjMsInZwI...ViNNCvoTQ-swSHwbELW7-EGPAcHLOMiIwE'
+    }
+  }
 }
- */
+*/
 ```

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "testEnvironment": "node"
   },
   "devDependencies": {
+    "@babel/plugin-proposal-optional-chaining": "^7.10.3",
     "@semantic-release/changelog": "5.0.1",
     "@semantic-release/git": "9.0.0",
     "@types/faker": "4.1.12",

--- a/src/__tests__/converters.test.ts
+++ b/src/__tests__/converters.test.ts
@@ -48,7 +48,7 @@ describe('credential', () => {
       it('merges credentialSubject objects', () => {
         const result = normalizeCredential({
           credentialSubject: { foo: 'bar' },
-          vc: { credentialSubject: { bar: 'baz' } }
+          vc: { credentialSubject: { bar: 'baz' }, '@context': [], type: [] }
         })
         expect(result).toMatchObject({ credentialSubject: { foo: 'bar', bar: 'baz' } })
       })
@@ -56,7 +56,7 @@ describe('credential', () => {
       it('merges credentialSubject objects with JWT precedence', () => {
         const result = normalizeCredential({
           credentialSubject: { foo: 'bar' },
-          vc: { credentialSubject: { foo: 'bazzz' } }
+          vc: { credentialSubject: { foo: 'bazzz' }, '@context': [], type: [] }
         })
         expect(result).toMatchObject({ credentialSubject: { foo: 'bazzz' } })
       })
@@ -133,12 +133,12 @@ describe('credential', () => {
       })
 
       it('merges type as arrays for single items', () => {
-        const result = normalizeCredential({ type: 'bar', vc: { type: 'foo' } })
+        const result = normalizeCredential({ type: 'bar', vc: { type: 'foo', '@context': [], credentialSubject: {} } })
         expect(result).toMatchObject({ type: ['bar', 'foo'] })
       })
 
       it('merges type as arrays uniquely', () => {
-        const result = normalizeCredential({ type: 'foo', vc: { type: 'foo' } })
+        const result = normalizeCredential({ type: 'foo', vc: { type: 'foo', '@context': [], credentialSubject: {} } })
         expect(result).toMatchObject({ type: ['foo'] })
         expect(result).not.toHaveProperty('vc')
       })
@@ -156,7 +156,7 @@ describe('credential', () => {
       })
 
       it('merges @context as arrays for single items', () => {
-        const result = normalizeCredential({ context: 'baz', '@context': 'bar', vc: { '@context': 'foo' } })
+        const result = normalizeCredential({ context: 'baz', '@context': 'bar', vc: { '@context': 'foo', type: [], credentialSubject: {} } })
         expect(result).toMatchObject({ '@context': ['baz', 'bar', 'foo'] })
       })
 
@@ -646,7 +646,7 @@ describe('presentation', () => {
         const result = normalizePresentation({
           '@context': ['foo', 'bar'],
           context: ['bar', 'baz', undefined, null],
-          vp: { '@context': ['bar', 'baz', 'bak'] }
+          vp: { '@context': ['bar', 'baz', 'bak'], type: [], verifiableCredential: [] }
         })
         expect(result).toMatchObject({ '@context': ['bar', 'baz', 'foo', 'bak'] })
       })

--- a/src/__tests__/converters.test.ts
+++ b/src/__tests__/converters.test.ts
@@ -1,4 +1,9 @@
-import { normalizeCredential, transformCredentialInput, normalizePresentation, transformPresentationInput } from '../converters'
+import {
+  normalizeCredential,
+  transformCredentialInput,
+  normalizePresentation,
+  transformPresentationInput
+} from '../converters'
 import { DEFAULT_JWT_PROOF_TYPE } from '../constants'
 
 function encodeBase64Url(input: string): string {
@@ -156,7 +161,11 @@ describe('credential', () => {
       })
 
       it('merges @context as arrays for single items', () => {
-        const result = normalizeCredential({ context: 'baz', '@context': 'bar', vc: { '@context': 'foo', type: [], credentialSubject: {} } })
+        const result = normalizeCredential({
+          context: 'baz',
+          '@context': 'bar',
+          vc: { '@context': 'foo', type: [], credentialSubject: {} }
+        })
         expect(result).toMatchObject({ '@context': ['baz', 'bar', 'foo'] })
       })
 
@@ -723,25 +732,41 @@ describe('presentation', () => {
 
     describe('verifiableCredential', () => {
       it('merges verifiableCredentials arrays', () => {
-        const result = transformPresentationInput({ verifiableCredential: [{ id: 'foo' }], vp: { verifiableCredential: [{ foo: 'bar' }, 'header.payload.signature'] } } as any)
-        expect(result).toMatchObject({ vp: { verifiableCredential: [{ id: 'foo' }, { foo: 'bar' }, 'header.payload.signature'] } })
+        const result = transformPresentationInput({
+          verifiableCredential: [{ id: 'foo' }],
+          vp: { verifiableCredential: [{ foo: 'bar' }, 'header.payload.signature'] }
+        } as any)
+        expect(result).toMatchObject({
+          vp: { verifiableCredential: [{ id: 'foo' }, { foo: 'bar' }, 'header.payload.signature'] }
+        })
         expect(result).not.toHaveProperty('verifiableCredential')
       })
 
       it('merges verifiableCredential arrays when not array types', () => {
-        const result = transformPresentationInput({ verifiableCredential: { id: 'foo' }, vp: { verifiableCredential: { foo: 'bar' } } } as any)
+        const result = transformPresentationInput({
+          verifiableCredential: { id: 'foo' },
+          vp: { verifiableCredential: { foo: 'bar' } }
+        } as any)
         expect(result).toMatchObject({ vp: { verifiableCredential: [{ id: 'foo' }, { foo: 'bar' }] } })
         expect(result).not.toHaveProperty('verifiableCredential')
       })
 
       it('condenses JWT credentials', () => {
-        const result = transformPresentationInput({ verifiableCredential: { id: 'foo', proof: { jwt: 'header.payload1.signature' } }, vp: { verifiableCredential: [{ foo: 'bar' }, 'header.payload2.signature'] } } as any)
-        expect(result).toMatchObject({ vp: { verifiableCredential: ['header.payload1.signature', { foo: 'bar' }, 'header.payload2.signature'] } })
+        const result = transformPresentationInput({
+          verifiableCredential: { id: 'foo', proof: { jwt: 'header.payload1.signature' } },
+          vp: { verifiableCredential: [{ foo: 'bar' }, 'header.payload2.signature'] }
+        } as any)
+        expect(result).toMatchObject({
+          vp: { verifiableCredential: ['header.payload1.signature', { foo: 'bar' }, 'header.payload2.signature'] }
+        })
         expect(result).not.toHaveProperty('verifiableCredential')
       })
 
       it('filters empty credentials', () => {
-        const result = transformPresentationInput({ verifiableCredential: undefined, vp: { verifiableCredential: [null, { foo: 'bar' }, 'header.payload2.signature'] } } as any)
+        const result = transformPresentationInput({
+          verifiableCredential: undefined,
+          vp: { verifiableCredential: [null, { foo: 'bar' }, 'header.payload2.signature'] }
+        } as any)
         expect(result).toMatchObject({ vp: { verifiableCredential: [{ foo: 'bar' }, 'header.payload2.signature'] } })
         expect(result).not.toHaveProperty('verifiableCredential')
       })
@@ -756,7 +781,11 @@ describe('presentation', () => {
       })
 
       it('merges @context fields when not array types', () => {
-        const result = transformPresentationInput({ context: 'AA', '@context': 'BB', vp: { '@context': ['CC'] } } as any)
+        const result = transformPresentationInput({
+          context: 'AA',
+          '@context': 'BB',
+          vp: { '@context': ['CC'] }
+        } as any)
         expect(result).toMatchObject({ vp: { '@context': ['AA', 'BB', 'CC'] } })
         expect(result).not.toHaveProperty('context')
         expect(result).not.toHaveProperty('@context')

--- a/src/__tests__/converters.test.ts
+++ b/src/__tests__/converters.test.ts
@@ -1,0 +1,296 @@
+import { normalizeCredential } from '../converters'
+import { DEFAULT_JWT_PROOF_TYPE } from '../constants'
+
+describe('credential', () => {
+  describe('transform payload to W3C', () => {
+    it('passes through empty payload', () => {
+      const result = normalizeCredential({})
+      expect(result).toMatchObject({})
+    })
+
+    it('passes through app specific properties', () => {
+      const result = normalizeCredential({ foo: 'bar' })
+      expect(result).toMatchObject({ foo: 'bar' })
+    })
+
+    describe('credentialSubject', () => {
+      it('keeps credentialSubject object', () => {
+        const result = normalizeCredential({ credentialSubject: { foo: 'bar' } })
+        expect(result).toMatchObject({ credentialSubject: { foo: 'bar' } })
+      })
+
+      it('interprets JWT sub as credential subject id', () => {
+        const result = normalizeCredential({ sub: 'example.com' })
+        expect(result).toMatchObject({ credentialSubject: { id: 'example.com' } })
+        expect(result).not.toHaveProperty('sub')
+      })
+
+      it('interprets JWT sub as credential subject id without overwriting existing', () => {
+        const result = normalizeCredential({ sub: 'foo', credentialSubject: { id: 'bar' } })
+        expect(result).toMatchObject({ sub: 'foo', credentialSubject: { id: 'bar' } })
+      })
+
+      it('merges credentialSubject objects', () => {
+        const result = normalizeCredential({
+          credentialSubject: { foo: 'bar' },
+          vc: { credentialSubject: { bar: 'baz' } }
+        })
+        expect(result).toMatchObject({ credentialSubject: { foo: 'bar', bar: 'baz' } })
+      })
+
+      it('merges credentialSubject objects with JWT precedence', () => {
+        const result = normalizeCredential({
+          credentialSubject: { foo: 'bar' },
+          vc: { credentialSubject: { foo: 'bazzz' } }
+        })
+        expect(result).toMatchObject({ credentialSubject: { foo: 'bazzz' } })
+      })
+    })
+
+    describe('issuer', () => {
+      it('accepts null issuer', () => {
+        const result = normalizeCredential({
+          issuer: null
+        })
+        expect(result).toMatchObject({})
+      })
+
+      it('parses iss as issuer id', () => {
+        const result = normalizeCredential({
+          iss: 'foo'
+        })
+        expect(result).toMatchObject({ issuer: { id: 'foo' } })
+        expect(result).not.toHaveProperty('iss')
+      })
+
+      it('keeps iss if issuer already has id', () => {
+        const result = normalizeCredential({
+          iss: 'foo',
+          issuer: {
+            id: 'bar'
+          }
+        })
+        expect(result).toMatchObject({ iss: 'foo', issuer: { id: 'bar' } })
+      })
+
+      it('keeps issuer claims', () => {
+        const result = normalizeCredential({
+          iss: 'foo',
+          issuer: {
+            bar: 'baz'
+          }
+        })
+        expect(result).toMatchObject({ issuer: { id: 'foo', bar: 'baz' } })
+        expect(result).not.toHaveProperty('iss')
+      })
+
+      it('keeps issuer if it is not an object', () => {
+        const result = normalizeCredential({
+          iss: 'foo',
+          issuer: 'baz'
+        })
+        expect(result).toMatchObject({ issuer: 'baz', iss: 'foo' })
+      })
+    })
+
+    describe('jti', () => {
+      it('transforms jti to id', () => {
+        const result = normalizeCredential({ jti: 'foo' })
+        expect(result).toMatchObject({ id: 'foo' })
+        expect(result).not.toHaveProperty('jti')
+      })
+
+      it('transforms jti to id if it is not present', () => {
+        const result = normalizeCredential({ jti: 'foo', id: 'bar' })
+        expect(result).toMatchObject({ id: 'bar', jti: 'foo' })
+      })
+    })
+
+    describe('type', () => {
+      it('uses type from vc', () => {
+        const result = normalizeCredential({ vc: { type: ['foo'] } })
+        expect(result).toMatchObject({ type: ['foo'] })
+      })
+
+      it('merges type arrays', () => {
+        const result = normalizeCredential({ type: ['bar'], vc: { type: ['foo'] } })
+        expect(result).toMatchObject({ type: ['bar', 'foo'] })
+      })
+
+      it('merges type as arrays for single items', () => {
+        const result = normalizeCredential({ type: 'bar', vc: { type: 'foo' } })
+        expect(result).toMatchObject({ type: ['bar', 'foo'] })
+      })
+
+      it('merges type as arrays uniquely', () => {
+        const result = normalizeCredential({ type: 'foo', vc: { type: 'foo' } })
+        expect(result).toMatchObject({ type: ['foo'] })
+        expect(result).not.toHaveProperty('vc')
+      })
+    })
+
+    describe('context', () => {
+      it('uses @context from vc', () => {
+        const result = normalizeCredential({ vc: { '@context': ['foo'] } })
+        expect(result).toMatchObject({ '@context': ['foo'] })
+      })
+
+      it('merges @context arrays', () => {
+        const result = normalizeCredential({ context: ['baz'], '@context': ['bar'], vc: { '@context': ['foo'] } })
+        expect(result).toMatchObject({ '@context': ['baz', 'bar', 'foo'] })
+      })
+
+      it('merges @context as arrays for single items', () => {
+        const result = normalizeCredential({ context: 'baz', '@context': 'bar', vc: { '@context': 'foo' } })
+        expect(result).toMatchObject({ '@context': ['baz', 'bar', 'foo'] })
+      })
+
+      it('merges @context as arrays uniquely', () => {
+        const result = normalizeCredential({
+          context: 'baz',
+          '@context': ['bar'],
+          vc: { '@context': ['foo', 'baz', 'bar'] }
+        })
+        expect(result).toMatchObject({ '@context': ['baz', 'bar', 'foo'] })
+        expect(result).not.toHaveProperty('vc')
+      })
+    })
+
+    describe('issuanceDate', () => {
+      it('keeps issuanceDate property when present', () => {
+        const result = normalizeCredential({ issuanceDate: 'yesterday', nbf: 1234567890, iat: 1111111111 })
+        expect(result).toMatchObject({ issuanceDate: 'yesterday', nbf: 1234567890, iat: 1111111111 })
+      })
+
+      it('uses nbf as issuanceDate when present', () => {
+        const result = normalizeCredential({ nbf: 1234567890, iat: 1111111111 })
+        expect(result).toMatchObject({ issuanceDate: '2009-02-13T23:31:30.000Z', iat: 1111111111 })
+        expect(result).not.toHaveProperty('nbf')
+      })
+
+      it('uses iat as issuanceDate when no nbf and no issuanceDate present', () => {
+        const result = normalizeCredential({ iat: 1111111111 })
+        expect(result).toMatchObject({ issuanceDate: '2005-03-18T01:58:31.000Z' })
+        expect(result).not.toHaveProperty('iat')
+      })
+    })
+
+    describe('expirationDate', () => {
+      it('keeps expirationDate property when present', () => {
+        const result = normalizeCredential({ expirationDate: 'tomorrow', exp: 1222222222 })
+        expect(result).toMatchObject({ expirationDate: 'tomorrow', exp: 1222222222 })
+      })
+
+      it('uses exp as issuanceDate when present', () => {
+        const result = normalizeCredential({ exp: 1222222222 })
+        expect(result).toMatchObject({ expirationDate: '2008-09-24T02:10:22.000Z' })
+        expect(result).not.toHaveProperty('exp')
+      })
+    })
+
+    describe('JWT payload', () => {
+      it('rejects unknown JSON string payload', () => {
+        expect(() => {
+          normalizeCredential('aaa')
+        }).toThrowError(/unknown credential format/)
+      })
+
+      it('rejects malformed JWT string payload 1', () => {
+        expect(() => {
+          normalizeCredential('a.b.c')
+        }).toThrowError(/unknown credential format/)
+      })
+
+      it('rejects malformed JWT string payload 2', () => {
+        expect(() => {
+          normalizeCredential('aaa.b.c')
+        }).toThrowError(/unknown credential format/)
+      })
+
+      const complexInput = {
+        context: 'top context',
+        '@context': ['also top'],
+        type: ['A'],
+        issuer: {
+          claim: 'issuer claim'
+        },
+        iss: 'foo',
+        sub: 'bar',
+        vc: {
+          '@context': ['vc context'],
+          type: ['B'],
+          credentialSubject: {
+            something: 'nothing'
+          },
+          appSpecific: 'some app specific field'
+        },
+        nbf: 1234567890,
+        iat: 1111111111,
+        exp: 1231231231,
+        appSpecific: 'another app specific field'
+      }
+
+      const expectedComplexOutput = {
+        '@context': ['top context', 'also top', 'vc context'],
+        type: ['A', 'B'],
+        issuer: {
+          id: 'foo',
+          claim: 'issuer claim'
+        },
+        credentialSubject: {
+          id: 'bar',
+          something: 'nothing'
+        },
+        issuanceDate: '2009-02-13T23:31:30.000Z',
+        expirationDate: '2009-01-06T08:40:31.000Z',
+        iat: 1111111111,
+        vc: {
+          appSpecific: 'some app specific field'
+        },
+        appSpecific: 'another app specific field'
+      }
+
+      it('accepts VerifiableCredential as string', () => {
+        const credential = JSON.stringify(complexInput)
+
+        const result = normalizeCredential(credential)
+
+        expect(result).toMatchObject(expectedComplexOutput)
+
+        expect(result).not.toHaveProperty('nbf')
+        expect(result).not.toHaveProperty('exp')
+        expect(result).not.toHaveProperty('sub')
+        expect(result).not.toHaveProperty('context')
+        expect(result.vc).not.toHaveProperty('@context')
+        expect(result.vc).not.toHaveProperty('type')
+        expect(result.vc).not.toHaveProperty('credentialSubject')
+      })
+
+      function encodeBase64Url(input: string): string {
+        return Buffer.from(input, 'utf-8').toString('base64').replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_')
+      }
+
+      it('accepts VerifiableCredential as JWT', () => {
+        const payload = JSON.stringify(complexInput)
+        const header = '{}'
+
+        const credential = `${encodeBase64Url(header)}.${encodeBase64Url(payload)}.signature`
+
+        const result = normalizeCredential(credential)
+
+        expect(result).toMatchObject(expectedComplexOutput)
+        expect(result).toHaveProperty('proof', { type: DEFAULT_JWT_PROOF_TYPE, jwt: credential })
+
+        expect(result).not.toHaveProperty('nbf')
+        expect(result).not.toHaveProperty('exp')
+        expect(result).not.toHaveProperty('sub')
+        expect(result).not.toHaveProperty('context')
+        expect(result.vc).not.toHaveProperty('@context')
+        expect(result.vc).not.toHaveProperty('type')
+        expect(result.vc).not.toHaveProperty('credentialSubject')
+      })
+    })
+  })
+})
+
+describe('presentation', () => {})

--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -1,5 +1,5 @@
 import EthrDID from 'ethr-did'
-import { createVerifiableCredential, createPresentation, verifyCredential, verifyPresentation } from '../index'
+import { createVerifiableCredentialJwt, createPresentationJwt, verifyCredential, verifyPresentation } from '../index'
 import { verifyJWT, decodeJWT } from 'did-jwt'
 import { DEFAULT_VC_TYPE, DEFAULT_VP_TYPE, DEFAULT_CONTEXT } from '../constants'
 import {
@@ -84,19 +84,19 @@ beforeEach(() => {
 
 describe('createVerifiableCredential', () => {
   it('creates a valid Verifiable Credential JWT with required fields', async () => {
-    const vcJwt = await createVerifiableCredential(verifiableCredentialPayload, did)
+    const vcJwt = await createVerifiableCredentialJwt(verifiableCredentialPayload, did)
     const decodedVc = await decodeJWT(vcJwt)
     const { iat, ...payload } = decodedVc.payload
     expect(payload).toMatchSnapshot()
   })
   it('creates a valid Verifiable Credential JWT with extra optional fields', async () => {
-    const vcJwt = await createVerifiableCredential({ ...verifiableCredentialPayload, extra: 42 }, did)
+    const vcJwt = await createVerifiableCredentialJwt({ ...verifiableCredentialPayload, extra: 42 }, did)
     const decodedVc = await decodeJWT(vcJwt)
     const { iat, ...payload } = decodedVc.payload
     expect(payload).toMatchSnapshot()
   })
   it('calls functions to validate required fields', async () => {
-    await createVerifiableCredential(verifiableCredentialPayload, did)
+    await createVerifiableCredentialJwt(verifiableCredentialPayload, did)
     expect(mockValidateTimestamp).toHaveBeenCalledWith(verifiableCredentialPayload.nbf)
     expect(mockValidateContext).toHaveBeenCalledWith(verifiableCredentialPayload.vc['@context'])
     expect(mockValidateVcType).toHaveBeenCalledWith(verifiableCredentialPayload.vc.type)
@@ -104,26 +104,26 @@ describe('createVerifiableCredential', () => {
   })
   it('calls functions to validate optional fields if they are present', async () => {
     const timestamp = Math.floor(new Date().getTime())
-    await createVerifiableCredential({ ...verifiableCredentialPayload, exp: timestamp }, did)
+    await createVerifiableCredentialJwt({ ...verifiableCredentialPayload, exp: timestamp }, did)
     expect(mockValidateTimestamp).toHaveBeenCalledWith(timestamp)
   })
 })
 
 describe('createPresentation', () => {
   it('creates a valid Presentation JWT with required fields', async () => {
-    const presentationJwt = await createPresentation(presentationPayload, did)
+    const presentationJwt = await createPresentationJwt(presentationPayload, did)
     const decodedPresentation = await decodeJWT(presentationJwt)
     const { iat, ...payload } = decodedPresentation.payload
     expect(payload).toMatchSnapshot()
   })
   it('creates a valid Presentation JWT with extra optional fields', async () => {
-    const presentationJwt = await createPresentation({ ...presentationPayload, extra: 42 }, did)
+    const presentationJwt = await createPresentationJwt({ ...presentationPayload, extra: 42 }, did)
     const decodedPresentation = await decodeJWT(presentationJwt)
     const { iat, ...payload } = decodedPresentation.payload
     expect(payload).toMatchSnapshot()
   })
   it('calls functions to validate required fields', async () => {
-    await createPresentation(presentationPayload, did)
+    await createPresentationJwt(presentationPayload, did)
     expect(mockValidateContext).toHaveBeenCalledWith(presentationPayload.vp['@context'])
     expect(mockValidateVpType).toHaveBeenCalledWith(presentationPayload.vp.type)
     for (const vc of presentationPayload.vp.verifiableCredential) {
@@ -132,7 +132,7 @@ describe('createPresentation', () => {
   })
   it('throws a TypeError if vp.verifiableCredential is empty', async () => {
     await expect(
-      createPresentation(
+      createPresentationJwt(
         {
           ...presentationPayload,
           vp: {
@@ -147,7 +147,7 @@ describe('createPresentation', () => {
   })
   it('calls functions to validate optional fields if they are present', async () => {
     const timestamp = Math.floor(new Date().getTime())
-    await createPresentation(
+    await createPresentationJwt(
       {
         ...presentationPayload,
         exp: timestamp

--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -1,5 +1,10 @@
 import EthrDID from 'ethr-did'
-import { createVerifiableCredentialJwt, verifyCredential, verifyPresentation, createVerifiablePresentationJwt } from '../index'
+import {
+  createVerifiableCredentialJwt,
+  verifyCredential,
+  verifyPresentation,
+  createVerifiablePresentationJwt
+} from '../index'
 import { verifyJWT, decodeJWT } from 'did-jwt'
 import { DEFAULT_VC_TYPE, DEFAULT_VP_TYPE, DEFAULT_CONTEXT } from '../constants'
 import {
@@ -164,11 +169,11 @@ describe('verifyCredential', () => {
     expect(verified.payload.vc).toBeDefined()
     expect(verified.verifiableCredential).toBeDefined()
   })
-  
+
   it('verifies and converts a legacy format attestation into a Verifiable Credential', async () => {
     // tslint:disable-next-line: max-line-length
     const LEGACY_FORMAT_ATTESTATION =
-    'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE1NjM4MjQ4MDksImV4cCI6OTk2Mjk1MDI4Miwic3ViIjoiZGlkOmV0aHI6MHhmMTIzMmY4NDBmM2FkN2QyM2ZjZGFhODRkNmM2NmRhYzI0ZWZiMTk4IiwiY2xhaW0iOnsiZGVncmVlIjp7InR5cGUiOiJCYWNoZWxvckRlZ3JlZSIsIm5hbWUiOiJCYWNjYWxhdXLDqWF0IGVuIG11c2lxdWVzIG51bcOpcmlxdWVzIn19LCJpc3MiOiJkaWQ6ZXRocjoweGYzYmVhYzMwYzQ5OGQ5ZTI2ODY1ZjM0ZmNhYTU3ZGJiOTM1YjBkNzQifQ.OsKmaxoA2pt3_ixWK61BaMDc072g2PymBX_CCUSo-irvtIRUP5qBCcerhpASe5hOcTg5nNpNg0XYXnqyF9I4XwE'
+      'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE1NjM4MjQ4MDksImV4cCI6OTk2Mjk1MDI4Miwic3ViIjoiZGlkOmV0aHI6MHhmMTIzMmY4NDBmM2FkN2QyM2ZjZGFhODRkNmM2NmRhYzI0ZWZiMTk4IiwiY2xhaW0iOnsiZGVncmVlIjp7InR5cGUiOiJCYWNoZWxvckRlZ3JlZSIsIm5hbWUiOiJCYWNjYWxhdXLDqWF0IGVuIG11c2lxdWVzIG51bcOpcmlxdWVzIn19LCJpc3MiOiJkaWQ6ZXRocjoweGYzYmVhYzMwYzQ5OGQ5ZTI2ODY1ZjM0ZmNhYTU3ZGJiOTM1YjBkNzQifQ.OsKmaxoA2pt3_ixWK61BaMDc072g2PymBX_CCUSo-irvtIRUP5qBCcerhpASe5hOcTg5nNpNg0XYXnqyF9I4XwE'
     const verified = await verifyCredential(LEGACY_FORMAT_ATTESTATION, resolver)
     // expect(verified.payload.vc).toBeDefined()
     expect(verified.verifiableCredential).toBeDefined()

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,3 +4,4 @@ export const JWT_FORMAT = /^[A-Za-z0-9-_=]+\.[A-Za-z0-9-_=]+\.?[A-Za-z0-9-_.+/=]
 export const DEFAULT_CONTEXT = 'https://www.w3.org/2018/credentials/v1'
 export const DEFAULT_VC_TYPE = 'VerifiableCredential'
 export const DEFAULT_VP_TYPE = 'VerifiablePresentation'
+export const DEFAULT_JWT_PROOF_TYPE = 'JwtProof2020'

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
-export const JWT_ALG = 'ES256K-R'
+export const JWT_ALG = 'ES256K'
 export const DID_FORMAT = /^did:([a-zA-Z0-9_]+):([:[a-zA-Z0-9_.-]+)(\/[^#]*)?(#.*)?$/
 export const JWT_FORMAT = /^[A-Za-z0-9-_=]+\.[A-Za-z0-9-_=]+\.?[A-Za-z0-9-_.+/=]*$/
 export const DEFAULT_CONTEXT = 'https://www.w3.org/2018/credentials/v1'

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -2,23 +2,23 @@ import {
   VerifiableCredential,
   JWT,
   JwtPresentationPayload,
-  JwtVerifiableCredentialPayload,
-  CredentialPayloadInput,
+  JwtCredentialPayload as JwtCredentialPayload,
+  CredentialPayload,
   Credential,
-  Verifiable
+  Verifiable,
+  PresentationPayload
 } from './types'
 import { decodeJWT } from 'did-jwt'
-import { VerifiableCredentialPayload } from 'src'
 
 function asArray(input: any) {
   return Array.isArray(input) ? input : [input]
 }
 
-function normalizeJwtCredentialPayload(input: Partial<JwtVerifiableCredentialPayload>): Credential {
-  let result: Partial<CredentialPayloadInput> = { ...input }
+function normalizeJwtCredentialPayload(input: Partial<JwtCredentialPayload>): Credential {
+  let result: Partial<CredentialPayload> = { ...input }
 
   result.credentialSubject = { ...result.credentialSubject, ...result.vc?.credentialSubject }
-  result.credentialSubject.id = result.credentialSubject.id || result.sub
+  result.credentialSubject.id = result.credentialSubject?.id || result.sub
   delete result.sub
 
   result.issuer = typeof result.issuer === 'object' ? { ...result.issuer, id: result.iss } : { id: result.iss }
@@ -62,7 +62,7 @@ function normalizeJwtCredential(input: JWT): Verifiable<Credential> {
  * @param input either a JWT or JWT payload, or a VerifiableCredential
  */
 export function normalizeCredential(
-  input: Partial<VerifiableCredential> | Partial<JwtVerifiableCredentialPayload>
+  input: Partial<VerifiableCredential> | Partial<JwtCredentialPayload>
 ): Verifiable<Credential> {
   if (typeof input === 'string') {
     //FIXME: attempt to deserialize as JSON before assuming it is a JWT
@@ -77,3 +77,67 @@ export function normalizeCredential(
   }
 }
 
+/**
+ * Transforms a W3C Credential payload into a JWT compatible encoding.
+ * The method accepts app specific fields and in case of collision, existing JWT properties will take precedence.
+ * @param input either a JWT payload or a CredentialPayloadInput
+ */
+export function transformCredentialInput(
+  input: Partial<CredentialPayload> | Partial<JwtCredentialPayload>
+): JwtCredentialPayload {
+  if (Array.isArray(input.credentialSubject)) throw Error('credentialSubject of type array not supported')
+
+  //TODO: test that app specific input.vc properties are preserved
+  const result: Partial<JwtCredentialPayload> = { vc: { ...input.vc }, ...input }
+
+  //TODO: test credentialSubject.id becomes sub and that original sub takes precedence
+  result.sub = input.sub || input.credentialSubject?.id
+  const credentialSubject = { ...input.credentialSubject, ...input.vc?.credentialSubject }
+  if (!input.sub) {
+    delete credentialSubject.id
+  }
+  result.vc.credentialSubject = credentialSubject
+
+  //TODO: check that all context combos are preserved
+  result.vc['@context'] = [...asArray(input.context), ...asArray(input['@context']), ...asArray(input.vc['@context'])]
+  delete result.context
+  delete result['@context']
+
+  //TODO: check that all type combos are preserved
+  result.vc.type = [...asArray(input.type), ...asArray(input.vc?.type)]
+  delete result.type
+
+  //TODO: check that existing jti is preserved and that id is used if not
+  if (input.id) {
+    result.jti = input.jti || input.id
+    delete result.id
+  }
+
+  //TODO: check that issuanceDate is used if present and that nbf is preserved if present
+  if (input.issuanceDate) {
+    result.nbf = input.nbf || Date.parse(input.issuanceDate) / 1000
+    delete result.issuanceDate
+  }
+
+  //TODO: check that expiryDate is used if present and that exp is preserved if present
+  if (input.expirationDate) {
+    result.exp = input.exp || Date.parse(input.expirationDate) / 1000
+    delete result.expirationDate
+  }
+
+  //TODO: check that iss is preserved, if present
+  //TODO: check that issuer is used as string if present
+  //TODO: check that issuer.id is used if iss is missing
+  //TODO: check that issuer claims are preserved, no matter what
+  if (input.issuer) {
+    if (typeof input.issuer === 'object') {
+      result.iss = input.iss || input.issuer?.id
+      delete result.issuer.id
+    } else {
+      result.iss = input.iss || '' + input.issuer
+      delete result.issuer
+    }
+  }
+
+  return result as JwtCredentialPayload
+}

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -1,0 +1,79 @@
+import {
+  VerifiableCredential,
+  JWT,
+  JwtPresentationPayload,
+  JwtVerifiableCredentialPayload,
+  CredentialPayloadInput,
+  Credential,
+  Verifiable
+} from './types'
+import { decodeJWT } from 'did-jwt'
+import { VerifiableCredentialPayload } from 'src'
+
+function asArray(input: any) {
+  return Array.isArray(input) ? input : [input]
+}
+
+function normalizeJwtCredentialPayload(input: Partial<JwtVerifiableCredentialPayload>): Credential {
+  let result: Partial<CredentialPayloadInput> = { ...input }
+
+  result.credentialSubject = { ...result.credentialSubject, ...result.vc?.credentialSubject }
+  result.credentialSubject.id = result.credentialSubject.id || result.sub
+  delete result.sub
+
+  result.issuer = typeof result.issuer === 'object' ? { ...result.issuer, id: result.iss } : { id: result.iss }
+  delete result.iss
+
+  result.id = result.id || result.jti
+  delete result.jti
+
+  result.type = [...asArray(result.type), ...asArray(result.vc.type)]
+  result['@context'] = [...asArray(result.context), ...asArray(result['@context']), ...asArray(result.vc['@context'])]
+  delete result.context
+  delete result.vc
+
+  //TODO: test parsing Date strings into Date objects
+  if (result.iat || result.nbf) {
+    result.issuanceDate = result.issuanceDate || new Date(result.nbf || result.iat).toISOString()
+    delete result.nbf
+    delete result.iat
+  }
+
+  if (result.exp) {
+    result.expirationDate = result.expirationDate || new Date(result.exp).toISOString()
+    delete result.exp
+  }
+
+  return result as Credential
+}
+
+function normalizeJwtCredential(input: JWT): Verifiable<Credential> {
+  return {
+    ...normalizeJwtCredentialPayload(decodeJWT(input)),
+    proof: {
+      type: 'JwtProof2020',
+      jwt: input
+    }
+  }
+}
+
+/**
+ * Normalizes a credential payload into an unambiguous W3C credential data type
+ * @param input either a JWT or JWT payload, or a VerifiableCredential
+ */
+export function normalizeCredential(
+  input: Partial<VerifiableCredential> | Partial<JwtVerifiableCredentialPayload>
+): Verifiable<Credential> {
+  if (typeof input === 'string') {
+    //FIXME: attempt to deserialize as JSON before assuming it is a JWT
+    return normalizeJwtCredential(input)
+  } else if (input.proof?.jwt) {
+    //TODO: test that it correctly propagates app specific proof properties
+    return { ...normalizeJwtCredential(input.proof.jwt), proof: input.proof }
+  } else {
+    //TODO: test that it accepts JWT payload, CredentialPayload, VerifiableCredential
+    //TODO: test that it correctly propagates proof, if any
+    return { proof: {}, ...normalizeJwtCredentialPayload(input) }
+  }
+}
+

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -56,7 +56,7 @@ function normalizeJwtCredentialPayload(input: Partial<JwtCredentialPayload>): Cr
     result = attestationToVcFormat(input)
   }
 
-  //FIXME: handle case when credentialSubject(s) are not object types
+  // FIXME: handle case when credentialSubject(s) are not object types
   result.credentialSubject = { ...input.credentialSubject, ...input.vc?.credentialSubject }
   if (input.sub && !input.credentialSubject?.id) {
     result.credentialSubject.id = input.sub
@@ -103,11 +103,11 @@ function normalizeJwtCredentialPayload(input: Partial<JwtCredentialPayload>): Cr
     delete result.exp
   }
 
-  if (result.vc && Object.keys(result.vc).length == 0) {
+  if (result.vc && Object.keys(result.vc).length === 0) {
     delete result.vc
   }
 
-  //FIXME: interpret `aud` property as `verifier`
+  // FIXME: interpret `aud` property as `verifier`
 
   return result as Credential
 }
@@ -117,9 +117,7 @@ function normalizeJwtCredential(input: JWT): Verifiable<Credential> {
   try {
     decoded = decodeJWT(input)
   } catch (e) {
-    const err = new Error('unknown credential format')
-    err['cause'] = e
-    throw err
+    throw new TypeError('unknown credential format')
   }
   return {
     ...normalizeJwtCredentialPayload(decoded.payload),
@@ -147,18 +145,16 @@ export function normalizeCredential(
       try {
         parsed = JSON.parse(input)
       } catch (e) {
-        const err = new Error('unknown credential format')
-        err['cause'] = e
-        throw err
+        throw new TypeError('unknown credential format')
       }
       return normalizeCredential(parsed)
     }
   } else if (input.proof?.jwt) {
-    //TODO: test that it correctly propagates app specific proof properties
+    // TODO: test that it correctly propagates app specific proof properties
     return { ...normalizeJwtCredential(input.proof.jwt), proof: input.proof }
   } else {
-    //TODO: test that it accepts JWT payload, CredentialPayload, VerifiableCredential
-    //TODO: test that it correctly propagates proof, if any
+    // TODO: test that it accepts JWT payload, CredentialPayload, VerifiableCredential
+    // TODO: test that it correctly propagates proof, if any
     return { proof: {}, ...normalizeJwtCredentialPayload(input) }
   }
 }
@@ -202,12 +198,12 @@ export function transformCredentialInput(
   result.vc.type = [...new Set(types)]
   delete result.type
 
-  if (input.id && Object.getOwnPropertyNames(input).indexOf('jti') == -1) {
+  if (input.id && Object.getOwnPropertyNames(input).indexOf('jti') === -1) {
     result.jti = input.id
     delete result.id
   }
 
-  if (input.issuanceDate && Object.getOwnPropertyNames(input).indexOf('nbf') == -1) {
+  if (input.issuanceDate && Object.getOwnPropertyNames(input).indexOf('nbf') === -1) {
     const converted = Date.parse(input.issuanceDate)
     if (!isNaN(converted)) {
       result.nbf = converted / 1000
@@ -215,7 +211,7 @@ export function transformCredentialInput(
     }
   }
 
-  if (input.expirationDate && Object.getOwnPropertyNames(input).indexOf('exp') == -1) {
+  if (input.expirationDate && Object.getOwnPropertyNames(input).indexOf('exp') === -1) {
     const converted = Date.parse(input.expirationDate)
     if (!isNaN(converted)) {
       result.exp = converted / 1000
@@ -223,18 +219,18 @@ export function transformCredentialInput(
     }
   }
 
-  if (input.issuer && Object.getOwnPropertyNames(input).indexOf('iss') == -1) {
+  if (input.issuer && Object.getOwnPropertyNames(input).indexOf('iss') === -1) {
     if (typeof input.issuer === 'object') {
       result.iss = input.issuer?.id
       delete result.issuer.id
-      if (Object.keys(result.issuer).length == 0) {
+      if (Object.keys(result.issuer).length === 0) {
         delete result.issuer
       }
     } else if (typeof input.issuer === 'string') {
       result.iss = input.iss || '' + input.issuer
       delete result.issuer
     } else {
-      //nop
+      // nop
     }
   }
 
@@ -242,7 +238,7 @@ export function transformCredentialInput(
 }
 
 function normalizeJwtPresentationPayload(input: DeepPartial<JwtPresentationPayload>): Presentation {
-  let result: Partial<PresentationPayload> = { ...input }
+  const result: Partial<PresentationPayload> = { ...input }
 
   result.verifiableCredential = [
     ...asArray(input.verifiableCredential),
@@ -262,7 +258,7 @@ function normalizeJwtPresentationPayload(input: DeepPartial<JwtPresentationPaylo
     delete result.aud
   }
 
-  if (input.jti && Object.getOwnPropertyNames(input).indexOf('id') == -1) {
+  if (input.jti && Object.getOwnPropertyNames(input).indexOf('id') === -1) {
     result.id = input.id || input.jti
     delete result.jti
   }
@@ -294,7 +290,7 @@ function normalizeJwtPresentationPayload(input: DeepPartial<JwtPresentationPaylo
     delete result.exp
   }
 
-  if (result.vp && Object.keys(result.vp).length == 0) {
+  if (result.vp && Object.keys(result.vp).length === 0) {
     delete result.vp
   }
 
@@ -306,9 +302,7 @@ function normalizeJwtPresentation(input: JWT): Verifiable<Presentation> {
   try {
     decoded = decodeJWT(input)
   } catch (e) {
-    const err = new Error('unknown presentation format')
-    err['cause'] = e
-    throw err
+    throw new TypeError('unknown presentation format')
   }
   return {
     ...normalizeJwtPresentationPayload(decoded.payload),
@@ -334,18 +328,16 @@ export function normalizePresentation(
       try {
         parsed = JSON.parse(input)
       } catch (e) {
-        const err = new Error('unknown presentation format')
-        err['cause'] = e
-        throw err
+        throw new TypeError('unknown presentation format')
       }
       return normalizePresentation(parsed)
     }
   } else if (input.proof?.jwt) {
-    //TODO: test that it correctly propagates app specific proof properties
+    // TODO: test that it correctly propagates app specific proof properties
     return { ...normalizeJwtPresentation(input.proof.jwt), proof: input.proof }
   } else {
-    //TODO: test that it accepts JWT payload, PresentationPayload, VerifiablePresentation
-    //TODO: test that it correctly propagates proof, if any
+    // TODO: test that it accepts JWT payload, PresentationPayload, VerifiablePresentation
+    // TODO: test that it correctly propagates proof, if any
     return { proof: {}, ...normalizeJwtPresentationPayload(input) }
   }
 }
@@ -374,12 +366,12 @@ export function transformPresentationInput(
   result.vp.type = [...new Set(types)]
   delete result.type
 
-  if (input.id && Object.getOwnPropertyNames(input).indexOf('jti') == -1) {
+  if (input.id && Object.getOwnPropertyNames(input).indexOf('jti') === -1) {
     result.jti = input.id
     delete result.id
   }
 
-  if (input.issuanceDate && Object.getOwnPropertyNames(input).indexOf('nbf') == -1) {
+  if (input.issuanceDate && Object.getOwnPropertyNames(input).indexOf('nbf') === -1) {
     const converted = Date.parse(input.issuanceDate)
     if (!isNaN(converted)) {
       result.nbf = converted / 1000
@@ -387,7 +379,7 @@ export function transformPresentationInput(
     }
   }
 
-  if (input.expirationDate && Object.getOwnPropertyNames(input).indexOf('exp') == -1) {
+  if (input.expirationDate && Object.getOwnPropertyNames(input).indexOf('exp') === -1) {
     const converted = Date.parse(input.expirationDate)
     if (!isNaN(converted)) {
       result.exp = converted / 1000
@@ -409,12 +401,12 @@ export function transformPresentationInput(
     })
   delete result.verifiableCredential
 
-  if (input.holder && Object.getOwnPropertyNames(input).indexOf('iss') == -1) {
+  if (input.holder && Object.getOwnPropertyNames(input).indexOf('iss') === -1) {
     if (typeof input.holder === 'string') {
       result.iss = input.holder
       delete result.holder
     } else {
-      //nop
+      // nop
     }
   }
 

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -12,7 +12,7 @@ import {
 import { decodeJWT } from 'did-jwt'
 import { JWT_FORMAT, DEFAULT_JWT_PROOF_TYPE, DEFAULT_CONTEXT, DEFAULT_VC_TYPE } from './constants'
 
-function asArray(input: any) {
+export function asArray(input: any) {
   return Array.isArray(input) ? input : [input]
 }
 
@@ -399,14 +399,14 @@ export function transformPresentationInput(
     ...asArray(result.verifiableCredential),
     ...asArray(result.vp?.verifiableCredential)
   ]
-  .filter(notEmpty)
-  .map((credential: VerifiableCredential) => {
-    if (typeof credential === 'object' && credential.proof?.jwt) {
-      return credential.proof.jwt
-    } else {
-      return credential
-    }
-  })
+    .filter(notEmpty)
+    .map((credential: VerifiableCredential) => {
+      if (typeof credential === 'object' && credential.proof?.jwt) {
+        return credential.proof.jwt
+      } else {
+        return credential
+      }
+    })
   delete result.verifiableCredential
 
   if (input.holder && Object.getOwnPropertyNames(input).indexOf('iss') == -1) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,17 @@
 import { createJWT, verifyJWT } from 'did-jwt'
 import { JWT_ALG, DEFAULT_CONTEXT, DEFAULT_VC_TYPE } from './constants'
 import * as validators from './validators'
-import { VerifiableCredentialPayload, Issuer, PresentationPayload } from './types'
+import { JwtVerifiableCredentialPayload, Issuer, JwtPresentationPayload } from './types'
 import { DIDDocument } from 'did-resolver'
 
-export { Issuer, VerifiableCredentialPayload, PresentationPayload }
+export { Issuer, JwtVerifiableCredentialPayload as VerifiableCredentialPayload, JwtPresentationPayload as PresentationPayload }
 
 interface Resolvable {
   resolve: (did: string) => Promise<DIDDocument>
 }
 
 export async function createVerifiableCredential(
-  payload: VerifiableCredentialPayload,
+  payload: JwtVerifiableCredentialPayload,
   issuer: Issuer
 ): Promise<string> {
   validateVerifiableCredentialAttributes(payload)
@@ -22,7 +22,7 @@ export async function createVerifiableCredential(
   })
 }
 
-export async function createPresentation(payload: PresentationPayload, issuer: Issuer): Promise<string> {
+export async function createPresentation(payload: JwtPresentationPayload, issuer: Issuer): Promise<string> {
   validatePresentationAttributes(payload)
   return createJWT(payload, {
     issuer: issuer.did,
@@ -31,7 +31,7 @@ export async function createPresentation(payload: PresentationPayload, issuer: I
   })
 }
 
-export function validateVerifiableCredentialAttributes(payload: VerifiableCredentialPayload): void {
+export function validateVerifiableCredentialAttributes(payload: JwtVerifiableCredentialPayload): void {
   validators.validateContext(payload.vc['@context'])
   validators.validateVcType(payload.vc.type)
   validators.validateCredentialSubject(payload.vc.credentialSubject)
@@ -39,7 +39,7 @@ export function validateVerifiableCredentialAttributes(payload: VerifiableCreden
   if (payload.exp) validators.validateTimestamp(payload.exp)
 }
 
-export function validatePresentationAttributes(payload: PresentationPayload): void {
+export function validatePresentationAttributes(payload: JwtPresentationPayload): void {
   validators.validateContext(payload.vp['@context'])
   validators.validateVpType(payload.vp.type)
   if (payload.vp.verifiableCredential.length < 1) {
@@ -56,9 +56,9 @@ function isLegacyAttestationFormat(payload: any): boolean {
   return payload instanceof Object && payload.sub && payload.iss && payload.claim && payload.iat
 }
 
-function attestationToVcFormat(payload: any): VerifiableCredentialPayload {
+function attestationToVcFormat(payload: any): JwtVerifiableCredentialPayload {
   const { iat, nbf, claim, vc, ...rest } = payload
-  const result: VerifiableCredentialPayload = {
+  const result: JwtVerifiableCredentialPayload = {
     ...rest,
     nbf: nbf ? nbf : iat,
     vc: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { createJWT, verifyJWT } from 'did-jwt'
-import { JWT_ALG, DEFAULT_CONTEXT, DEFAULT_VC_TYPE } from './constants'
+import { JWT_ALG, DEFAULT_CONTEXT, DEFAULT_VC_TYPE, DEFAULT_JWT_PROOF_TYPE } from './constants'
 import * as validators from './validators'
 import {
   JwtCredentialPayload,
@@ -7,28 +7,39 @@ import {
   JwtPresentationPayload,
   JWT,
   VerifiablePresentation,
-  VerifiableCredential
+  VerifiableCredential,
+  CredentialPayload,
+  PresentationPayload,
+  Verifiable,
+  Credential,
+  Presentation,
+  VerifiedCredential,
+  VerifiedPresentation,
+  Verified
 } from './types'
 import { DIDDocument } from 'did-resolver'
+import { transformCredentialInput, transformPresentationInput, normalizePresentation, normalizeCredential, isLegacyAttestationFormat, attestationToVcFormat } from './converters'
 
-export { Issuer, JwtCredentialPayload, JwtPresentationPayload, VerifiableCredential, VerifiablePresentation }
+export { Issuer, JwtCredentialPayload, JwtPresentationPayload, VerifiableCredential, VerifiablePresentation, VerifiedCredential, VerifiedPresentation }
 
 interface Resolvable {
   resolve: (did: string) => Promise<DIDDocument>
 }
 
-export async function createVerifiableCredentialJwt(payload: JwtCredentialPayload, issuer: Issuer): Promise<JWT> {
-  validateJwtVerifiableCredentialPayload(payload)
-  return createJWT(payload, {
+export async function createVerifiableCredentialJwt(payload: JwtCredentialPayload | CredentialPayload, issuer: Issuer): Promise<JWT> {
+  const parsedPayload = transformCredentialInput(payload)
+  validateJwtVerifiableCredentialPayload(parsedPayload)
+  return createJWT(parsedPayload, {
     issuer: issuer.did,
     signer: issuer.signer,
     alg: issuer.alg || JWT_ALG
   })
 }
 
-export async function createPresentationJwt(payload: JwtPresentationPayload, issuer: Issuer): Promise<JWT> {
-  validateJwtPresentationPayload(payload)
-  return createJWT(payload, {
+export async function createVerifiablePresentationJwt(payload: JwtPresentationPayload | PresentationPayload, issuer: Issuer): Promise<JWT> {
+  const parsedPayload = transformPresentationInput(payload)
+  validateJwtPresentationPayload(parsedPayload)
+  return createJWT(parsedPayload, {
     issuer: issuer.did,
     signer: issuer.signer,
     alg: issuer.alg || JWT_ALG
@@ -43,6 +54,14 @@ export function validateJwtVerifiableCredentialPayload(payload: JwtCredentialPay
   if (payload.exp) validators.validateTimestamp(payload.exp)
 }
 
+export function validateVerifiableCredentialPayload(payload: CredentialPayload): void {
+  validators.validateContext(payload['@context'])
+  validators.validateVcType(payload.type)
+  validators.validateCredentialSubject(payload.credentialSubject)
+  if (payload.issuanceDate) validators.validateTimestamp(new Date(payload.issuanceDate).valueOf() / 1000)
+  if (payload.expirationDate) validators.validateTimestamp(new Date(payload.expirationDate).valueOf() / 1000)
+}
+
 export function validateJwtPresentationPayload(payload: JwtPresentationPayload): void {
   validators.validateContext(payload.vp['@context'])
   validators.validateVpType(payload.vp.type)
@@ -55,24 +74,20 @@ export function validateJwtPresentationPayload(payload: JwtPresentationPayload):
   if (payload.exp) validators.validateTimestamp(payload.exp)
 }
 
-function isLegacyAttestationFormat(payload: any): boolean {
-  // payload is an object and has all the required fields of old attestation format
-  return payload instanceof Object && payload.sub && payload.iss && payload.claim && payload.iat
-}
-
-function attestationToVcFormat(payload: any): JwtCredentialPayload {
-  const { iat, nbf, claim, vc, ...rest } = payload
-  const result: JwtCredentialPayload = {
-    ...rest,
-    nbf: nbf ? nbf : iat,
-    vc: {
-      '@context': [DEFAULT_CONTEXT],
-      type: [DEFAULT_VC_TYPE],
-      credentialSubject: payload.claim
+export function validatePresentationPayload(payload: PresentationPayload): void {
+  validators.validateContext(payload['@context'])
+  validators.validateVpType(payload.type)
+  if (payload.verifiableCredential.length < 1) {
+    throw new TypeError('vp.verifiableCredential must not be empty')
+  }
+  for (const vc of payload.verifiableCredential) {
+    if (typeof vc === 'string') {
+      validators.validateJwtFormat(vc)
+    } else {
+      validateVerifiableCredentialPayload(vc)
     }
   }
-  if (vc) payload.issVc = vc
-  return result
+  if (payload.expirationDate) validators.validateTimestamp(payload.expirationDate)
 }
 
 export async function verifyCredential(vc: JWT, resolver: Resolvable): Promise<any> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,11 @@ import * as validators from './validators'
 import { JwtVerifiableCredentialPayload, Issuer, JwtPresentationPayload, JWT } from './types'
 import { DIDDocument } from 'did-resolver'
 
-export { Issuer, JwtVerifiableCredentialPayload as VerifiableCredentialPayload, JwtPresentationPayload as PresentationPayload }
+export {
+  Issuer,
+  JwtVerifiableCredentialPayload as VerifiableCredentialPayload,
+  JwtPresentationPayload as PresentationPayload
+}
 
 interface Resolvable {
   resolve: (did: string) => Promise<DIDDocument>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,15 @@
 import { createJWT, verifyJWT } from 'did-jwt'
 import { JWT_ALG, DEFAULT_CONTEXT, DEFAULT_VC_TYPE } from './constants'
 import * as validators from './validators'
-import { JwtVerifiableCredentialPayload, Issuer, JwtPresentationPayload, JWT } from './types'
+import { JwtCredentialPayload, Issuer, JwtPresentationPayload, JWT, VerifiablePresentation, VerifiableCredential } from './types'
 import { DIDDocument } from 'did-resolver'
 
 export {
   Issuer,
-  JwtVerifiableCredentialPayload as VerifiableCredentialPayload,
-  JwtPresentationPayload as PresentationPayload
+  JwtCredentialPayload,
+  JwtPresentationPayload,
+  VerifiableCredential,
+  VerifiablePresentation
 }
 
 interface Resolvable {
@@ -15,7 +17,7 @@ interface Resolvable {
 }
 
 export async function createVerifiableCredentialJwt(
-  payload: JwtVerifiableCredentialPayload,
+  payload: JwtCredentialPayload,
   issuer: Issuer
 ): Promise<JWT> {
   validateJwtVerifiableCredentialPayload(payload)
@@ -35,7 +37,7 @@ export async function createPresentationJwt(payload: JwtPresentationPayload, iss
   })
 }
 
-export function validateJwtVerifiableCredentialPayload(payload: JwtVerifiableCredentialPayload): void {
+export function validateJwtVerifiableCredentialPayload(payload: JwtCredentialPayload): void {
   validators.validateContext(payload.vc['@context'])
   validators.validateVcType(payload.vc.type)
   validators.validateCredentialSubject(payload.vc.credentialSubject)
@@ -60,9 +62,9 @@ function isLegacyAttestationFormat(payload: any): boolean {
   return payload instanceof Object && payload.sub && payload.iss && payload.claim && payload.iat
 }
 
-function attestationToVcFormat(payload: any): JwtVerifiableCredentialPayload {
+function attestationToVcFormat(payload: any): JwtCredentialPayload {
   const { iat, nbf, claim, vc, ...rest } = payload
-  const result: JwtVerifiableCredentialPayload = {
+  const result: JwtCredentialPayload = {
     ...rest,
     nbf: nbf ? nbf : iat,
     vc: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,25 +1,23 @@
 import { createJWT, verifyJWT } from 'did-jwt'
 import { JWT_ALG, DEFAULT_CONTEXT, DEFAULT_VC_TYPE } from './constants'
 import * as validators from './validators'
-import { JwtCredentialPayload, Issuer, JwtPresentationPayload, JWT, VerifiablePresentation, VerifiableCredential } from './types'
+import {
+  JwtCredentialPayload,
+  Issuer,
+  JwtPresentationPayload,
+  JWT,
+  VerifiablePresentation,
+  VerifiableCredential
+} from './types'
 import { DIDDocument } from 'did-resolver'
 
-export {
-  Issuer,
-  JwtCredentialPayload,
-  JwtPresentationPayload,
-  VerifiableCredential,
-  VerifiablePresentation
-}
+export { Issuer, JwtCredentialPayload, JwtPresentationPayload, VerifiableCredential, VerifiablePresentation }
 
 interface Resolvable {
   resolve: (did: string) => Promise<DIDDocument>
 }
 
-export async function createVerifiableCredentialJwt(
-  payload: JwtCredentialPayload,
-  issuer: Issuer
-): Promise<JWT> {
+export async function createVerifiableCredentialJwt(payload: JwtCredentialPayload, issuer: Issuer): Promise<JWT> {
   validateJwtVerifiableCredentialPayload(payload)
   return createJWT(payload, {
     issuer: issuer.did,

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,15 +18,34 @@ import {
   Verified
 } from './types'
 import { DIDDocument } from 'did-resolver'
-import { transformCredentialInput, transformPresentationInput, normalizePresentation, normalizeCredential, isLegacyAttestationFormat, attestationToVcFormat } from './converters'
+import {
+  transformCredentialInput,
+  transformPresentationInput,
+  normalizePresentation,
+  normalizeCredential,
+  isLegacyAttestationFormat,
+  attestationToVcFormat,
+  asArray
+} from './converters'
 
-export { Issuer, JwtCredentialPayload, JwtPresentationPayload, VerifiableCredential, VerifiablePresentation, VerifiedCredential, VerifiedPresentation }
+export {
+  Issuer,
+  JwtCredentialPayload,
+  JwtPresentationPayload,
+  VerifiableCredential,
+  VerifiablePresentation,
+  VerifiedCredential,
+  VerifiedPresentation
+}
 
 interface Resolvable {
   resolve: (did: string) => Promise<DIDDocument>
 }
 
-export async function createVerifiableCredentialJwt(payload: JwtCredentialPayload | CredentialPayload, issuer: Issuer): Promise<JWT> {
+export async function createVerifiableCredentialJwt(
+  payload: JwtCredentialPayload | CredentialPayload,
+  issuer: Issuer
+): Promise<JWT> {
   const parsedPayload = transformCredentialInput(payload)
   validateJwtVerifiableCredentialPayload(parsedPayload)
   return createJWT(parsedPayload, {
@@ -36,7 +55,10 @@ export async function createVerifiableCredentialJwt(payload: JwtCredentialPayloa
   })
 }
 
-export async function createVerifiablePresentationJwt(payload: JwtPresentationPayload | PresentationPayload, issuer: Issuer): Promise<JWT> {
+export async function createVerifiablePresentationJwt(
+  payload: JwtPresentationPayload | PresentationPayload,
+  issuer: Issuer
+): Promise<JWT> {
   const parsedPayload = transformPresentationInput(payload)
   validateJwtPresentationPayload(parsedPayload)
   return createJWT(parsedPayload, {
@@ -68,8 +90,12 @@ export function validateJwtPresentationPayload(payload: JwtPresentationPayload):
   if (payload.vp.verifiableCredential.length < 1) {
     throw new TypeError('vp.verifiableCredential must not be empty')
   }
-  for (const vc of payload.vp.verifiableCredential) {
-    validators.validateJwtFormat(vc)
+  for (const vc of asArray(payload.vp.verifiableCredential)) {
+    if (typeof vc === 'string') {
+      validators.validateJwtFormat(vc)
+    } else {
+      validateVerifiableCredentialPayload(vc)
+    }
   }
   if (payload.exp) validators.validateTimestamp(payload.exp)
 }
@@ -90,17 +116,16 @@ export function validatePresentationPayload(payload: PresentationPayload): void 
   if (payload.expirationDate) validators.validateTimestamp(payload.expirationDate)
 }
 
-export async function verifyCredential(vc: JWT, resolver: Resolvable): Promise<any> {
-  const verified = await verifyJWT(vc, { resolver })
-  if (isLegacyAttestationFormat(verified.payload)) {
-    verified.payload = attestationToVcFormat(verified.payload)
-  }
-  validateJwtVerifiableCredentialPayload(verified.payload)
-  return verified
+export async function verifyCredential(vc: JWT, resolver: Resolvable): Promise<VerifiedCredential> {
+  const verified: Partial<VerifiedCredential> = await verifyJWT(vc, { resolver })
+  verified.verifiableCredential = normalizeCredential(verified.jwt)
+  validateVerifiableCredentialPayload(verified.verifiableCredential)
+  return verified as VerifiedCredential
 }
 
-export async function verifyPresentation(presentation: JWT, resolver: Resolvable): Promise<any> {
-  const verified = await verifyJWT(presentation, { resolver })
-  validateJwtPresentationPayload(verified.payload)
-  return verified
+export async function verifyPresentation(presentation: JWT, resolver: Resolvable): Promise<VerifiedPresentation> {
+  const verified: Partial<VerifiedPresentation> = await verifyJWT(presentation, { resolver })
+  verified.verifiablePresentation = normalizePresentation(verified.jwt)
+  validatePresentationPayload(verified.verifiablePresentation)
+  return verified as VerifiedPresentation
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,30 +9,26 @@ export interface CredentialStatus {
   type: string
 }
 
-export interface VC {
-  '@context': string[]
-  type: string[]
-  credentialSubject: JwtCredentialSubject
-}
-
 export interface JwtVerifiableCredentialPayload {
   sub: string
-  vc: VC
+  vc: {
+    '@context': string[]
+    type: string[]
+    credentialSubject: JwtCredentialSubject
+  }
   nbf?: number
   aud?: string
   exp?: number
   jti?: string
   [x: string]: any
-}
-
-export interface VP {
-  '@context': string[]
-  type: string[]
-  verifiableCredential: string[]
 }
 
 export interface JwtPresentationPayload {
-  vp: VP
+  vp: {
+    '@context': string[]
+    type: string[]
+    verifiableCredential: string[]
+  }
   aud?: string
   nbf?: number
   exp?: number
@@ -40,7 +36,46 @@ export interface JwtPresentationPayload {
   [x: string]: any
 }
 
+/**
+ * used as input when creating Verifiable Credentials
+ */
+export interface CredentialPayload {
+  '@context': string[]
+  id?: string
+  type: string[]
+  issuer: string
+  issuanceDate: Date | string
+  expirationDate?: Date | string
+  credentialSubject: {
+    id: string,
+    [x: string]: any
+  }
+  credentialStatus?: CredentialStatus
+  //application specific fields
+  [x: string]: any
+}
+
+/**
+* used as input when creating Verifiable Presentations
+*/
+export interface PresentationPayload {
+  '@context': string[]
+  type: string[]
+  id?: string
+  verifiableCredential: VerifiableCredential[]
+  holder: string
+}
+
+export interface Proof {
+  type?: string
+  [x: string]: any
+}
+
+export type Verifiable<T> = T & { proof: Proof }
 export type JWT = string
+
+export type VerifiablePresentation = Verifiable<PresentationPayload> | JWT
+export type VerifiableCredential = Verifiable<CredentialPayload> | JWT
 
 export interface Issuer {
   did: string

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,7 +17,7 @@ export interface JwtCredentialPayload {
     credentialSubject: JwtCredentialSubject
   }
   nbf?: number
-  aud?: string
+  aud?: string | string[]
   exp?: number
   jti?: string
   [x: string]: any
@@ -36,7 +36,7 @@ export interface JwtPresentationPayload {
   [x: string]: any
 }
 
-export type IssuerType = { id: string;[x: string]: any } | string
+export type IssuerType = { id: string; [x: string]: any } | string
 export type DateType = string | Date
 /**
  * used as input when creating Verifiable Credentials
@@ -74,11 +74,11 @@ type Replace<T, U> = Omit<T, keyof U> & U
 /**
  * This data type represents a parsed VerifiableCredential.
  * It is meant to be an unambiguous representation of the properties of a Credential and is usually the result of a transformation method.
- * 
+ *
  * `issuer` is always an object with an `id` property and potentially other app specific issuer claims
  * `issuanceDate` is an ISO DateTime string
  * `expirationDate`, is a nullable ISO DateTime string
- * 
+ *
  * Any JWT specific properties are transformed to the broader W3C variant and any app specific properties are left intact
  */
 export type Credential = Replace<CredentialPayload, NarrowCredentialDefinitions>
@@ -104,7 +104,7 @@ interface NarrowPresentationDefinitions {
 /**
  * This data type represents a parsed Presentation payload.
  * It is meant to be an unambiguous representation of the properties of a Presentation and is usually the result of a transformation method.
- * 
+ *
  * The `verifiableCredential` array should contain parsed `Verifiable<Credential>` elements.
  * Any JWT specific properties are transformed to the broader W3C variant and any other app specific properties are left intact.
  */

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,11 +11,12 @@ export interface CredentialStatus {
 
 export interface JwtCredentialPayload {
   sub: string
-  vc: Extensible<{
+  vc: {
     '@context': string[] | string
     type: string[] | string
     credentialSubject: JwtCredentialSubject
-  }>
+    [x: string]: any
+  }
   nbf?: number
   aud?: string | string[]
   exp?: number
@@ -24,11 +25,12 @@ export interface JwtCredentialPayload {
 }
 
 export interface JwtPresentationPayload {
-  vp: Extensible<{
+  vp: {
     '@context': string[] | string
     type: string[] | string
     verifiableCredential: VerifiableCredential[] | VerifiableCredential
-  }>
+    [x: string]: any
+  }
   aud?: string | string[]
   nbf?: number
   exp?: number
@@ -36,7 +38,7 @@ export interface JwtPresentationPayload {
   [x: string]: any
 }
 
-export type IssuerType = { id: string;[x: string]: any } | string
+export type IssuerType = { id: string; [x: string]: any } | string
 export type DateType = string | Date
 /**
  * used as input when creating Verifiable Credentials
@@ -124,8 +126,8 @@ export type JWT = string
 export type VerifiablePresentation = Verifiable<Presentation> | JWT
 export type VerifiableCredential = JWT | Verifiable<Credential>
 
-type UnpackedPromise<T> = T extends Promise<infer U> ? U : T;
-export type Verified = UnpackedPromise<ReturnType<typeof verifyJWT>>;
+type UnpackedPromise<T> = T extends Promise<infer U> ? U : T
+export type Verified = UnpackedPromise<ReturnType<typeof verifyJWT>>
 
 export type VerifiedPresentation = Verified & {
   verifiablePresentation: Verifiable<Presentation>

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,18 +36,20 @@ export interface JwtPresentationPayload {
   [x: string]: any
 }
 
+export type IssuerType = { id: string; [x: string]: any } | string
+export type DateType = string | Date
 /**
  * used as input when creating Verifiable Credentials
  */
-export interface CredentialPayload {
+export interface CredentialPayloadInput {
   '@context': string[]
   id?: string
   type: string[]
-  issuer: string
-  issuanceDate: Date | string
-  expirationDate?: Date | string
+  issuer: IssuerType
+  issuanceDate: DateType
+  expirationDate?: DateType
   credentialSubject: {
-    id: string,
+    id: string
     [x: string]: any
   }
   credentialStatus?: CredentialStatus
@@ -56,8 +58,24 @@ export interface CredentialPayload {
 }
 
 /**
-* used as input when creating Verifiable Presentations
-*/
+ * This is meant to reflect unambiguous types for the properties in `CredentialPayloadInput`
+ */
+interface NarrowDefinitions {
+  issuer: Exclude<IssuerType, string>
+  issuanceDate: string
+  expirationDate?: string
+}
+
+/**
+ * Replaces the matching property types of T with the ones in U
+ */
+type Replace<T, U> = Omit<T, keyof U> & U
+
+export type Credential = Replace<CredentialPayloadInput, NarrowDefinitions>
+
+/**
+ * used as input when creating Verifiable Presentations
+ */
 export interface PresentationPayload {
   '@context': string[]
   type: string[]
@@ -71,11 +89,11 @@ export interface Proof {
   [x: string]: any
 }
 
-export type Verifiable<T> = T & { proof: Proof }
+export type Verifiable<T> = Readonly<T> & { proof: Proof }
 export type JWT = string
 
 export type VerifiablePresentation = Verifiable<PresentationPayload> | JWT
-export type VerifiableCredential = Verifiable<CredentialPayload> | JWT
+export type VerifiableCredential = Verifiable<CredentialPayloadInput> | JWT
 
 export interface Issuer {
   did: string

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,7 +43,7 @@ export type DateType = string | Date
 /**
  * used as input when creating Verifiable Credentials
  */
-interface ICredentialPayload {
+interface FixedCredentialPayload {
   '@context': string[]
   id?: string
   type: string[]
@@ -57,7 +57,7 @@ interface ICredentialPayload {
   credentialStatus?: CredentialStatus
 }
 
-export type CredentialPayload = Extensible<ICredentialPayload>
+export type CredentialPayload = Extensible<FixedCredentialPayload>
 
 /**
  * This is meant to reflect unambiguous types for the properties in `CredentialPayload`
@@ -84,12 +84,12 @@ type Extensible<T> = T & { [x: string]: any }
  *
  * Any JWT specific properties are transformed to the broader W3C variant and any app specific properties are left intact
  */
-export type Credential = Extensible<Replace<ICredentialPayload, NarrowCredentialDefinitions>>
+export type Credential = Extensible<Replace<FixedCredentialPayload, NarrowCredentialDefinitions>>
 
 /**
  * used as input when creating Verifiable Presentations
  */
-export interface IPresentationPayload {
+export interface FixedPresentationPayload {
   '@context': string[]
   type: string[]
   id?: string
@@ -100,7 +100,7 @@ export interface IPresentationPayload {
   expirationDate?: string
 }
 
-export type PresentationPayload = Extensible<IPresentationPayload>
+export type PresentationPayload = Extensible<FixedPresentationPayload>
 
 interface NarrowPresentationDefinitions {
   verifiableCredential: Verifiable<Credential>[]
@@ -113,7 +113,7 @@ interface NarrowPresentationDefinitions {
  * The `verifiableCredential` array should contain parsed `Verifiable<Credential>` elements.
  * Any JWT specific properties are transformed to the broader W3C variant and any other app specific properties are left intact.
  */
-export type Presentation = Extensible<Replace<IPresentationPayload, NarrowPresentationDefinitions>>
+export type Presentation = Extensible<Replace<FixedPresentationPayload, NarrowPresentationDefinitions>>
 
 export interface Proof {
   type?: string

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 import { Signer } from 'did-jwt'
 
-export interface CredentialSubject {
+export interface JwtCredentialSubject {
   [x: string]: any
 }
 
@@ -12,10 +12,10 @@ export interface CredentialStatus {
 export interface VC {
   '@context': string[]
   type: string[]
-  credentialSubject: CredentialSubject
+  credentialSubject: JwtCredentialSubject
 }
 
-export interface VerifiableCredentialPayload {
+export interface JwtVerifiableCredentialPayload {
   sub: string
   vc: VC
   nbf?: number
@@ -31,7 +31,7 @@ export interface VP {
   verifiableCredential: string[]
 }
 
-export interface PresentationPayload {
+export interface JwtPresentationPayload {
   vp: VP
   aud?: string
   nbf?: number

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,9 +27,9 @@ export interface JwtPresentationPayload {
   vp: {
     '@context': string[]
     type: string[]
-    verifiableCredential: string[]
+    verifiableCredential: VerifiableCredential[]
   }
-  aud?: string
+  aud?: string | string[]
   nbf?: number
   exp?: number
   jti?: string
@@ -119,7 +119,7 @@ export type Verifiable<T> = Readonly<T> & { proof: Proof }
 export type JWT = string
 
 export type VerifiablePresentation = Verifiable<Presentation> | JWT
-export type VerifiableCredential = Verifiable<Credential> | JWT
+export type VerifiableCredential = JWT | Verifiable<Credential>
 
 export interface Issuer {
   did: string

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,6 +40,8 @@ export interface JwtPresentationPayload {
   [x: string]: any
 }
 
+export type JWT = string
+
 export interface Issuer {
   did: string
   signer: Signer

--- a/src/types.ts
+++ b/src/types.ts
@@ -127,13 +127,13 @@ export type VerifiablePresentation = Verifiable<Presentation> | JWT
 export type VerifiableCredential = JWT | Verifiable<Credential>
 
 type UnpackedPromise<T> = T extends Promise<infer U> ? U : T
-export type Verified = UnpackedPromise<ReturnType<typeof verifyJWT>>
+export type VerifiedJWT = UnpackedPromise<ReturnType<typeof verifyJWT>>
 
-export type VerifiedPresentation = Verified & {
+export type VerifiedPresentation = VerifiedJWT & {
   verifiablePresentation: Verifiable<Presentation>
 }
 
-export type VerifiedCredential = Verified & {
+export type VerifiedCredential = VerifiedJWT & {
   verifiableCredential: Verifiable<Credential>
 }
 

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -1,8 +1,9 @@
 import { DID_FORMAT, DEFAULT_CONTEXT, DEFAULT_VC_TYPE, DEFAULT_VP_TYPE, JWT_FORMAT } from './constants'
 import { JwtCredentialSubject } from './types'
+import { VerifiableCredential } from 'src'
 
-export function validateJwtFormat(value: string): void {
-  if (!value.match(JWT_FORMAT)) {
+export function validateJwtFormat(value: VerifiableCredential): void {
+  if (typeof value === 'string' && !value.match(JWT_FORMAT)) {
     throw new TypeError(`"${value}" is not a valid JWT format`)
   }
 }

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -1,5 +1,5 @@
 import { DID_FORMAT, DEFAULT_CONTEXT, DEFAULT_VC_TYPE, DEFAULT_VP_TYPE, JWT_FORMAT } from './constants'
-import { CredentialSubject } from './types'
+import { JwtCredentialSubject } from './types'
 
 export function validateJwtFormat(value: string): void {
   if (!value.match(JWT_FORMAT)) {
@@ -38,7 +38,7 @@ export function validateVpType(value: string[]): void {
   }
 }
 
-export function validateCredentialSubject(value: CredentialSubject): void {
+export function validateCredentialSubject(value: JwtCredentialSubject): void {
   if (Object.keys(value).length === 0) {
     throw new TypeError('credentialSubject must not be empty')
   }

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -30,21 +30,21 @@ export function validateTimestamp(value: number | string): void {
 
 export function validateContext(value: string | string[]): void {
   const input = asArray(value)
-  if (input.length < 1 || input.indexOf(DEFAULT_CONTEXT) == -1) {
+  if (input.length < 1 || input.indexOf(DEFAULT_CONTEXT) === -1) {
     throw new TypeError(`@context is missing default context "${DEFAULT_CONTEXT}"`)
   }
 }
 
 export function validateVcType(value: string | string[]): void {
   const input = asArray(value)
-  if (input.length < 1 || input.indexOf(DEFAULT_VC_TYPE) == -1) {
+  if (input.length < 1 || input.indexOf(DEFAULT_VC_TYPE) === -1) {
     throw new TypeError(`type is missing default "${DEFAULT_VC_TYPE}"`)
   }
 }
 
 export function validateVpType(value: string | string[]): void {
   const input = asArray(value)
-  if (input.length < 1 || input.indexOf(DEFAULT_VP_TYPE) == -1) {
+  if (input.length < 1 || input.indexOf(DEFAULT_VP_TYPE) === -1) {
     throw new TypeError(`type is missing default "${DEFAULT_VP_TYPE}"`)
   }
 }

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -15,9 +15,15 @@ export function validateJwtFormat(value: VerifiableCredential): void {
 // 10 digits max is 9999999999 -> 11/20/2286 @ 5:46pm (UTC)
 // 11 digits max is 99999999999 -> 11/16/5138 @ 9:46am (UTC)
 // 12 digits max is 999999999999 -> 09/27/33658 @ 1:46am (UTC)
-export function validateTimestamp(value: number): void {
-  if (!(Number.isInteger(value) && value < 100000000000)) {
-    throw new TypeError(`"${value}" is not a unix timestamp in seconds`)
+export function validateTimestamp(value: number | string): void {
+  if (typeof value === 'number') {
+    if (!(Number.isInteger(value) && value < 100000000000)) {
+      throw new TypeError(`"${value}" is not a unix timestamp in seconds`)
+    }
+  } else if (typeof value === 'string') {
+    validateTimestamp(new Date(value).valueOf() / 1000)
+  } else {
+    throw new TypeError(`"${value}" is not a valid time`)
   }
 }
 

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -1,6 +1,7 @@
 import { DID_FORMAT, DEFAULT_CONTEXT, DEFAULT_VC_TYPE, DEFAULT_VP_TYPE, JWT_FORMAT } from './constants'
 import { JwtCredentialSubject } from './types'
 import { VerifiableCredential } from 'src'
+import { asArray } from './converters'
 
 export function validateJwtFormat(value: VerifiableCredential): void {
   if (typeof value === 'string' && !value.match(JWT_FORMAT)) {
@@ -27,20 +28,23 @@ export function validateTimestamp(value: number | string): void {
   }
 }
 
-export function validateContext(value: string[]): void {
-  if (value.length < 1 || !value.includes(DEFAULT_CONTEXT)) {
+export function validateContext(value: string | string[]): void {
+  const input = asArray(value)
+  if (input.length < 1 || input.indexOf(DEFAULT_CONTEXT) == -1) {
     throw new TypeError(`@context is missing default context "${DEFAULT_CONTEXT}"`)
   }
 }
 
-export function validateVcType(value: string[]): void {
-  if (value.length < 1 || !value.includes(DEFAULT_VC_TYPE)) {
+export function validateVcType(value: string | string[]): void {
+  const input = asArray(value)
+  if (input.length < 1 || input.indexOf(DEFAULT_VC_TYPE) == -1) {
     throw new TypeError(`type is missing default "${DEFAULT_VC_TYPE}"`)
   }
 }
 
-export function validateVpType(value: string[]): void {
-  if (value.length < 1 || !value.includes(DEFAULT_VP_TYPE)) {
+export function validateVpType(value: string | string[]): void {
+  const input = asArray(value)
+  if (input.length < 1 || input.indexOf(DEFAULT_VP_TYPE) == -1) {
     throw new TypeError(`type is missing default "${DEFAULT_VP_TYPE}"`)
   }
 }


### PR DESCRIPTION
Fixes #34

The API of this library was only suitable for directly encoding, creating and verifying [w3c verifiable credentials](https://www.w3.org/TR/vc-data-model) already converted to the JWT requirements.

This adds several methods to transform `Credential` and `Presentation` formats to and from [jwt-encoding](https://www.w3.org/TR/vc-data-model/#jwt-encoding) to standard [W3C encoding](https://www.w3.org/TR/vc-data-model)

Some methods and type definitions have been changed to homogenize the API.

The idea here is to accept wide data types in creation and verification parameters and to return narrow data types that can be more easily interpreted.

**Renamed types**:
`VerifiableCredentialPayload` -> `JwtCredentialPayload`
`PresentationPayload` -> `JwtPresentationPayload`
These are JWT compliant parameter data types usable when creating credentials

**New parameter types**:
`CredentialPayload` and `PresentationPayload` -> W3C compliant parameter data types usable when creating credentials
`Verifiable<Credential>` and `Verifiable<Presentation>` -> W3C compliant return types

**Homogenous format**
This PR also proposes a `JwtProof2020` proof property for credentials that allows the description of JWT credentials in an expanded, W3C compliant format.

For `JWT` credentials and presentations, the expanded format is a parsed JWT payload interpreted as a W3C Credential/Presentation with the full JWT appended as a `proof` property.
When verifying, the parsed and expanded properties are ignored since the signed data is embedded in the JWT representation.

**New return types**
`VerifiedCredential` and `VerifiedPresentation` are returned by the verification methods.
These add a `verifiableCredential` property, respectively a `verifiablePresentation` property to the object returned by each verification method. These new properties contain the expanded W3C compliant representation of the credential/presentation that was just verified.

**Method renames**
`createVerifiableCredential()` -> `createVerifiableCredentialJwt()`
`createPresentation()` -> `createVerifiablePresentationJwt()`
`validateVerifiableCredentialAttributes()` -> `validateJwtCredentialPayload()`
`validatePresentationAttributes()` -> `validateJwtPresentationPayload()`

**New methods**
`transformCredentialInput([Jwt]CredentialPayload): JwtCredentialPayload`
`transformPresentationInput([Jwt]PresentationPayload): JwtPresentationPayload`
`normalizeCredential(JWT | VerifiableCredential): Verifiable<Credential>` - normalizes/expands a Credential or payload to the W3C standard representation
`normalizePresentation(JWT | VerifiablePresentation): Verifiable<Presentation>` - normalizes/expands a Presentation to the W3C standard representation