### PR TITLE
[Bugfix] input transformation when creating JWT

### DIFF
--- a/src/__tests__/converters.test.ts
+++ b/src/__tests__/converters.test.ts
@@ -550,7 +550,7 @@ describe('presentation', () => {
         const result = normalizePresentation({
           verifiableCredential: { foo: 'bar' },
           vp: { verifiableCredential: [{ foo: 'baz' }] }
-        } as any)
+        })
         expect(result).toMatchObject({
           verifiableCredential: [{ foo: 'bar' }, { foo: 'baz' }]
         })
@@ -646,7 +646,7 @@ describe('presentation', () => {
       })
 
       it('merges type arrays for non-array types', () => {
-        const result = normalizePresentation({ type: 'foo', vp: { type: 'bar' } } as any)
+        const result = normalizePresentation({ type: 'foo', vp: { type: 'bar' } })
         expect(result).toMatchObject({ type: ['foo', 'bar'] })
         expect(result).not.toHaveProperty('vp')
       })
@@ -666,7 +666,7 @@ describe('presentation', () => {
       })
 
       it('merges @context arrays for non-array contexts', () => {
-        const result = normalizePresentation({ '@context': 'foo', context: 'bar', vp: { '@context': 'baz' } } as any)
+        const result = normalizePresentation({ '@context': 'foo', context: 'bar', vp: { '@context': 'baz' } })
         expect(result).toMatchObject({ '@context': ['bar', 'foo', 'baz'] })
         expect(result).not.toHaveProperty('vp')
         expect(result).not.toHaveProperty('context')
@@ -773,7 +773,7 @@ describe('presentation', () => {
         const result = transformPresentationInput({
           verifiableCredential: [{ id: 'foo' }],
           vp: { verifiableCredential: [{ foo: 'bar' }, 'header.payload.signature'] }
-        } as any)
+        })
         expect(result).toMatchObject({
           vp: { verifiableCredential: [{ id: 'foo' }, { foo: 'bar' }, 'header.payload.signature'] }
         })
@@ -784,7 +784,7 @@ describe('presentation', () => {
         const result = transformPresentationInput({
           verifiableCredential: { id: 'foo' },
           vp: { verifiableCredential: { foo: 'bar' } }
-        } as any)
+        })
         expect(result).toMatchObject({ vp: { verifiableCredential: [{ id: 'foo' }, { foo: 'bar' }] } })
         expect(result).not.toHaveProperty('verifiableCredential')
       })
@@ -793,7 +793,7 @@ describe('presentation', () => {
         const result = transformPresentationInput({
           verifiableCredential: { id: 'foo', proof: { jwt: 'header.payload1.signature' } },
           vp: { verifiableCredential: [{ foo: 'bar' }, 'header.payload2.signature'] }
-        } as any)
+        })
         expect(result).toMatchObject({
           vp: { verifiableCredential: ['header.payload1.signature', { foo: 'bar' }, 'header.payload2.signature'] }
         })
@@ -804,7 +804,7 @@ describe('presentation', () => {
         const result = transformPresentationInput({
           verifiableCredential: undefined,
           vp: { verifiableCredential: [null, { foo: 'bar' }, 'header.payload2.signature'] }
-        } as any)
+        })
         expect(result).toMatchObject({ vp: { verifiableCredential: [{ foo: 'bar' }, 'header.payload2.signature'] } })
         expect(result).not.toHaveProperty('verifiableCredential')
       })
@@ -823,7 +823,7 @@ describe('presentation', () => {
           context: 'AA',
           '@context': 'BB',
           vp: { '@context': ['CC'] }
-        } as any)
+        })
         expect(result).toMatchObject({ vp: { '@context': ['AA', 'BB', 'CC'] } })
         expect(result).not.toHaveProperty('context')
         expect(result).not.toHaveProperty('@context')
@@ -854,7 +854,7 @@ describe('presentation', () => {
       })
 
       it('merges type fields when not array types', () => {
-        const result = transformPresentationInput({ type: 'AA', vp: { type: ['BB'] } } as any)
+        const result = transformPresentationInput({ type: 'AA', vp: { type: ['BB'] } })
         expect(result).toMatchObject({ vp: { type: ['AA', 'BB'] } })
         expect(result).not.toHaveProperty('type')
       })

--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -5,7 +5,7 @@ import {
   verifyPresentation,
   createVerifiablePresentationJwt
 } from '../index'
-import { verifyJWT, decodeJWT } from 'did-jwt'
+import { decodeJWT } from 'did-jwt'
 import { DEFAULT_VC_TYPE, DEFAULT_VP_TYPE, DEFAULT_CONTEXT } from '../constants'
 import {
   validateContext,

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -318,7 +318,7 @@ function normalizeJwtPresentation(input: JWT): Verifiable<W3CPresentation> {
  * @param input either a JWT or JWT payload, or a VerifiablePresentation
  */
 export function normalizePresentation(
-  input: Partial<PresentationPayload> | Partial<JwtPresentationPayload> | JWT
+  input: Partial<PresentationPayload> | DeepPartial<JwtPresentationPayload> | JWT
 ): Verifiable<W3CPresentation> {
   if (typeof input === 'string') {
     if (JWT_FORMAT.test(input)) {
@@ -349,7 +349,7 @@ export function normalizePresentation(
  * @param input either a JWT payload or a CredentialPayloadInput
  */
 export function transformPresentationInput(
-  input: Partial<PresentationPayload> | Partial<JwtPresentationPayload>
+  input: Partial<PresentationPayload> | DeepPartial<JwtPresentationPayload>
 ): JwtPresentationPayload {
   const result: Partial<JwtPresentationPayload> = { vp: { ...input.vp }, ...input }
 

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -4,10 +4,10 @@ import {
   JwtPresentationPayload,
   JwtCredentialPayload,
   CredentialPayload,
-  Credential,
+  W3CCredential,
   Verifiable,
   PresentationPayload,
-  Presentation
+  W3CPresentation
 } from './types'
 import { decodeJWT } from 'did-jwt'
 import { JWT_FORMAT, DEFAULT_JWT_PROOF_TYPE, DEFAULT_CONTEXT, DEFAULT_VC_TYPE } from './constants'
@@ -49,7 +49,7 @@ export function attestationToVcFormat(payload: any): JwtCredentialPayload {
   return result
 }
 
-function normalizeJwtCredentialPayload(input: Partial<JwtCredentialPayload>): Credential {
+function normalizeJwtCredentialPayload(input: Partial<JwtCredentialPayload>): W3CCredential {
   let result: Partial<CredentialPayload> = { ...input }
 
   if (isLegacyAttestationFormat(input)) {
@@ -109,10 +109,10 @@ function normalizeJwtCredentialPayload(input: Partial<JwtCredentialPayload>): Cr
 
   // FIXME: interpret `aud` property as `verifier`
 
-  return result as Credential
+  return result as W3CCredential
 }
 
-function normalizeJwtCredential(input: JWT): Verifiable<Credential> {
+function normalizeJwtCredential(input: JWT): Verifiable<W3CCredential> {
   let decoded
   try {
     decoded = decodeJWT(input)
@@ -136,7 +136,7 @@ function normalizeJwtCredential(input: JWT): Verifiable<Credential> {
  */
 export function normalizeCredential(
   input: Partial<VerifiableCredential> | Partial<JwtCredentialPayload>
-): Verifiable<Credential> {
+): Verifiable<W3CCredential> {
   if (typeof input === 'string') {
     if (JWT_FORMAT.test(input)) {
       return normalizeJwtCredential(input)
@@ -206,7 +206,7 @@ export function transformCredentialInput(
   if (input.issuanceDate && Object.getOwnPropertyNames(input).indexOf('nbf') === -1) {
     const converted = Date.parse(input.issuanceDate)
     if (!isNaN(converted)) {
-      result.nbf = converted / 1000
+      result.nbf = Math.floor(converted / 1000)
       delete result.issuanceDate
     }
   }
@@ -214,7 +214,7 @@ export function transformCredentialInput(
   if (input.expirationDate && Object.getOwnPropertyNames(input).indexOf('exp') === -1) {
     const converted = Date.parse(input.expirationDate)
     if (!isNaN(converted)) {
-      result.exp = converted / 1000
+      result.exp = Math.floor(converted / 1000)
       delete result.expirationDate
     }
   }
@@ -237,7 +237,7 @@ export function transformCredentialInput(
   return result as JwtCredentialPayload
 }
 
-function normalizeJwtPresentationPayload(input: DeepPartial<JwtPresentationPayload>): Presentation {
+function normalizeJwtPresentationPayload(input: DeepPartial<JwtPresentationPayload>): W3CPresentation {
   const result: Partial<PresentationPayload> = { ...input }
 
   result.verifiableCredential = [
@@ -294,10 +294,10 @@ function normalizeJwtPresentationPayload(input: DeepPartial<JwtPresentationPaylo
     delete result.vp
   }
 
-  return result as Presentation
+  return result as W3CPresentation
 }
 
-function normalizeJwtPresentation(input: JWT): Verifiable<Presentation> {
+function normalizeJwtPresentation(input: JWT): Verifiable<W3CPresentation> {
   let decoded
   try {
     decoded = decodeJWT(input)
@@ -319,7 +319,7 @@ function normalizeJwtPresentation(input: JWT): Verifiable<Presentation> {
  */
 export function normalizePresentation(
   input: Partial<PresentationPayload> | Partial<JwtPresentationPayload> | JWT
-): Verifiable<Presentation> {
+): Verifiable<W3CPresentation> {
   if (typeof input === 'string') {
     if (JWT_FORMAT.test(input)) {
       return normalizeJwtPresentation(input)
@@ -374,7 +374,7 @@ export function transformPresentationInput(
   if (input.issuanceDate && Object.getOwnPropertyNames(input).indexOf('nbf') === -1) {
     const converted = Date.parse(input.issuanceDate)
     if (!isNaN(converted)) {
-      result.nbf = converted / 1000
+      result.nbf = Math.floor(converted / 1000)
       delete result.issuanceDate
     }
   }
@@ -382,7 +382,7 @@ export function transformPresentationInput(
   if (input.expirationDate && Object.getOwnPropertyNames(input).indexOf('exp') === -1) {
     const converted = Date.parse(input.expirationDate)
     if (!isNaN(converted)) {
-      result.exp = converted / 1000
+      result.exp = Math.floor(converted / 1000)
       delete result.expirationDate
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,8 @@ import {
 
 export {
   Issuer,
+  CredentialPayload,
+  PresentationPayload,
   JwtCredentialPayload,
   JwtPresentationPayload,
   VerifiableCredential,
@@ -112,9 +114,8 @@ export function validateCredentialPayload(payload: CredentialPayload): void {
   validators.validateContext(payload['@context'])
   validators.validateVcType(payload.type)
   validators.validateCredentialSubject(payload.credentialSubject)
-  if (payload.issuanceDate) validators.validateTimestamp(Math.floor(new Date(payload.issuanceDate).valueOf() / 1000))
-  if (payload.expirationDate)
-    validators.validateTimestamp(Math.floor(new Date(payload.expirationDate).valueOf() / 1000))
+  if (payload.issuanceDate) validators.validateTimestamp(payload.issuanceDate)
+  if (payload.expirationDate) validators.validateTimestamp(payload.expirationDate)
 }
 
 export function validateJwtPresentationPayload(payload: JwtPresentationPayload): void {

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,9 +46,9 @@ export type DateType = string | Date
  * used as input when creating Verifiable Credentials
  */
 interface FixedCredentialPayload {
-  '@context': string[]
+  '@context': string | string[]
   id?: string
-  type: string[]
+  type: string | string[]
   issuer: IssuerType
   issuanceDate: DateType
   expirationDate?: DateType
@@ -65,6 +65,8 @@ export type CredentialPayload = Extensible<FixedCredentialPayload>
  * This is meant to reflect unambiguous types for the properties in `CredentialPayload`
  */
 interface NarrowCredentialDefinitions {
+  '@context': string[]
+  type: string[]
   issuer: Exclude<IssuerType, string>
   issuanceDate: string
   expirationDate?: string
@@ -92,12 +94,12 @@ export type W3CCredential = Extensible<Replace<FixedCredentialPayload, NarrowCre
  * used as input when creating Verifiable Presentations
  */
 export interface FixedPresentationPayload {
-  '@context': string[]
-  type: string[]
+  '@context': string | string[]
+  type: string | string[]
   id?: string
   verifiableCredential: VerifiableCredential[]
   holder: string
-  verifier?: string[]
+  verifier?: string | string[]
   issuanceDate?: string
   expirationDate?: string
 }
@@ -105,6 +107,9 @@ export interface FixedPresentationPayload {
 export type PresentationPayload = Extensible<FixedPresentationPayload>
 
 interface NarrowPresentationDefinitions {
+  '@context': string[]
+  type: string[]
+  verifier: string[]
   verifiableCredential: Verifiable<W3CCredential>[]
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,7 @@ export interface CredentialStatus {
 }
 
 export interface JwtCredentialPayload {
+  iss?: string
   sub: string
   vc: {
     '@context': string[] | string
@@ -31,6 +32,7 @@ export interface JwtPresentationPayload {
     verifiableCredential: VerifiableCredential[] | VerifiableCredential
     [x: string]: any
   }
+  iss?: string
   aud?: string | string[]
   nbf?: number
   exp?: number
@@ -84,7 +86,7 @@ type Extensible<T> = T & { [x: string]: any }
  *
  * Any JWT specific properties are transformed to the broader W3C variant and any app specific properties are left intact
  */
-export type Credential = Extensible<Replace<FixedCredentialPayload, NarrowCredentialDefinitions>>
+export type W3CCredential = Extensible<Replace<FixedCredentialPayload, NarrowCredentialDefinitions>>
 
 /**
  * used as input when creating Verifiable Presentations
@@ -103,7 +105,7 @@ export interface FixedPresentationPayload {
 export type PresentationPayload = Extensible<FixedPresentationPayload>
 
 interface NarrowPresentationDefinitions {
-  verifiableCredential: Verifiable<Credential>[]
+  verifiableCredential: Verifiable<W3CCredential>[]
 }
 
 /**
@@ -113,7 +115,7 @@ interface NarrowPresentationDefinitions {
  * The `verifiableCredential` array should contain parsed `Verifiable<Credential>` elements.
  * Any JWT specific properties are transformed to the broader W3C variant and any other app specific properties are left intact.
  */
-export type Presentation = Extensible<Replace<FixedPresentationPayload, NarrowPresentationDefinitions>>
+export type W3CPresentation = Extensible<Replace<FixedPresentationPayload, NarrowPresentationDefinitions>>
 
 export interface Proof {
   type?: string
@@ -123,18 +125,18 @@ export interface Proof {
 export type Verifiable<T> = Readonly<T> & { proof: Proof }
 export type JWT = string
 
-export type VerifiablePresentation = Verifiable<Presentation> | JWT
-export type VerifiableCredential = JWT | Verifiable<Credential>
+export type VerifiablePresentation = Verifiable<W3CPresentation> | JWT
+export type VerifiableCredential = JWT | Verifiable<W3CCredential>
 
 type UnpackedPromise<T> = T extends Promise<infer U> ? U : T
 export type VerifiedJWT = UnpackedPromise<ReturnType<typeof verifyJWT>>
 
 export type VerifiedPresentation = VerifiedJWT & {
-  verifiablePresentation: Verifiable<Presentation>
+  verifiablePresentation: Verifiable<W3CPresentation>
 }
 
 export type VerifiedCredential = VerifiedJWT & {
-  verifiableCredential: Verifiable<Credential>
+  verifiableCredential: Verifiable<W3CCredential>
 }
 
 export interface Issuer {

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -1,7 +1,11 @@
-import { DID_FORMAT, DEFAULT_CONTEXT, DEFAULT_VC_TYPE, DEFAULT_VP_TYPE, JWT_FORMAT } from './constants'
-import { JwtCredentialSubject } from './types'
+import { DEFAULT_CONTEXT, DEFAULT_VC_TYPE, DEFAULT_VP_TYPE, JWT_FORMAT } from './constants'
+import { JwtCredentialSubject, DateType } from './types'
 import { VerifiableCredential } from 'src'
 import { asArray } from './converters'
+
+function isDateObject(input: any) {
+  return input && Object.prototype.toString.call(input) === '[object Date]' && !isNaN(input)
+}
 
 export function validateJwtFormat(value: VerifiableCredential): void {
   if (typeof value === 'string' && !value.match(JWT_FORMAT)) {
@@ -16,14 +20,14 @@ export function validateJwtFormat(value: VerifiableCredential): void {
 // 10 digits max is 9999999999 -> 11/20/2286 @ 5:46pm (UTC)
 // 11 digits max is 99999999999 -> 11/16/5138 @ 9:46am (UTC)
 // 12 digits max is 999999999999 -> 09/27/33658 @ 1:46am (UTC)
-export function validateTimestamp(value: number | string): void {
+export function validateTimestamp(value: number | DateType): void {
   if (typeof value === 'number') {
     if (!(Number.isInteger(value) && value < 100000000000)) {
       throw new TypeError(`"${value}" is not a unix timestamp in seconds`)
     }
   } else if (typeof value === 'string') {
-    validateTimestamp(new Date(value).valueOf() / 1000)
-  } else {
+    validateTimestamp(Math.floor(new Date(value).valueOf() / 1000))
+  } else if (!isDateObject(value)) {
     throw new TypeError(`"${value}" is not a valid time`)
   }
 }


### PR DESCRIPTION
### Fixes
* use Math.floor when converting Date strings to unix timestamps
  This fixes #37
* rename `Credential` and `Presentation` types to `W3CCredential` and `W3CPresentation` to avoid confusion with typescript native definitions

### Improvements
* `iat` is not added to JWT if not explicitly requested
* Data types used as input to creation/transformation methods are wider
* use `issuer`/`holder`/`iss` of payload when creating JWT if no `did` is specified in the `Issuer` parameter
