### PR TITLE
uses commonjs modules

### DIFF
--- a/src/__tests__/converters.test.ts
+++ b/src/__tests__/converters.test.ts
@@ -691,7 +691,7 @@ describe('credential', () => {
         const input = {
           '@context': ['https://www.w3.org/2018/credentials/v1'],
           type: ['VerifiableCredential'],
-          issuer: { id: 'did:example:567'},
+          issuer: { id: 'did:example:567' },
           issuanceDate: '2020-07-02T09:58:10.284Z',
           credentialSubject: { id: 'did:example:123', foo: 'bar' }
         }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     /* Basic Options */
     "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
-    "module": "umd",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     "lib": ["dom", "es6","es2015.promise"],          /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */


### PR DESCRIPTION
this is not useable from a Create React / Typescript context. It fails with:

```
./lib/did-jwt-vc/lib/index.js | converters | validators | constants

Critical dependency: require function is used in a way in which dependencies cannot be statically extracted
```

not sure why you went with umd here, but when switching to commonjs that works nicely :innocent: 
-> switched ts module config from UMD to commonjs

( + linter whitespace change)