### PR TITLE
fix: w3c additional props should not be overwritten inside JWT

### DIFF
--- a/src/__tests__/converters.test.ts
+++ b/src/__tests__/converters.test.ts
@@ -427,33 +427,33 @@ describe('credential', () => {
 
     describe('other W3C fields', () => {
       it('uses evidence from vc', () => {
-        const result = normalizeCredential({ vc: { evidence: 'foo'} })
+        const result = normalizeCredential({ vc: { evidence: 'foo' } })
         expect(result).toMatchObject({ evidence: 'foo' })
       })
 
       it('uses evidence from vc, keeping originals', () => {
         const result = normalizeCredential({ vc: { evidence: 'foo' } }, false)
-        expect(result).toMatchObject({ evidence: 'foo', vc: { evidence: 'foo'} })
+        expect(result).toMatchObject({ evidence: 'foo', vc: { evidence: 'foo' } })
       })
 
       it('uses credentialStatus from vc', () => {
-        const result = normalizeCredential({ vc: { credentialStatus: 'foo'} })
+        const result = normalizeCredential({ vc: { credentialStatus: 'foo' } })
         expect(result).toMatchObject({ credentialStatus: 'foo' })
       })
 
       it('uses credentialStatus from vc, keeping originals', () => {
         const result = normalizeCredential({ vc: { credentialStatus: 'foo' } }, false)
-        expect(result).toMatchObject({ credentialStatus: 'foo', vc: { credentialStatus: 'foo'} })
+        expect(result).toMatchObject({ credentialStatus: 'foo', vc: { credentialStatus: 'foo' } })
       })
 
       it('uses termsOfUse from vc', () => {
-        const result = normalizeCredential({ vc: { termsOfUse: 'foo'} })
+        const result = normalizeCredential({ vc: { termsOfUse: 'foo' } })
         expect(result).toMatchObject({ termsOfUse: 'foo' })
       })
 
       it('uses termsOfUse from vc, keeping originals', () => {
         const result = normalizeCredential({ vc: { termsOfUse: 'foo' } }, false)
-        expect(result).toMatchObject({ termsOfUse: 'foo', vc: { termsOfUse: 'foo'} })
+        expect(result).toMatchObject({ termsOfUse: 'foo', vc: { termsOfUse: 'foo' } })
       })
     })
 
@@ -969,6 +969,11 @@ describe('credential', () => {
         expect(result).toMatchObject({ evidence: 'foo', vc: { evidence: 'foo' } })
       })
 
+      it('does not overwrite existing evidence', () => {
+        const result = transformCredentialInput({ vc: { evidence: 'foo' } })
+        expect(result).toMatchObject({ vc: { evidence: 'foo' } })
+      })
+
       it('maps credentialStatus to vc', () => {
         const result = transformCredentialInput({ credentialStatus: 'foo' })
         expect(result).toMatchObject({ vc: { credentialStatus: 'foo' } })
@@ -989,6 +994,19 @@ describe('credential', () => {
       it('maps termsOfUse to vc, keeping originals', () => {
         const result = transformCredentialInput({ termsOfUse: 'foo' }, false)
         expect(result).toMatchObject({ termsOfUse: 'foo', vc: { termsOfUse: 'foo' } })
+      })
+
+      it('does not overwrite existing termsOfUse', () => {
+        const result = transformCredentialInput({ vc: { termsOfUse: 'foo' } })
+        expect(result).toMatchObject({ vc: { termsOfUse: 'foo' } })
+      })
+
+      it('does not introduce new keys', () => {
+        const result = transformCredentialInput({ vc: { foo: 'bar' } })
+        expect(result.vc).not.toHaveProperty('credentialSchema')
+        expect(result.vc).not.toHaveProperty('credentialStatus')
+        expect(result.vc).not.toHaveProperty('evidence')
+        expect(result.vc).not.toHaveProperty('termsOfUse')
       })
     })
   })

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -252,11 +252,6 @@ export function transformCredentialInput(
     }
   }
 
-  result.vc.credentialStatus = input.credentialStatus
-  if (removeOriginalFields) {
-    delete result.credentialStatus
-  }
-
   const contextEntries = [
     ...asArray(input.context),
     ...asArray(input['@context']),
@@ -320,20 +315,24 @@ export function transformCredentialInput(
     }
   }
 
-  // additional W3C VC fields to map:
   result.vc.credentialSubject = credentialSubject
   if (removeOriginalFields) {
     delete result.credentialSubject
   }
 
-  result.vc.evidence = input.evidence
-  if (removeOriginalFields) {
-    delete result.evidence
-  }
+  // additional W3C VC fields to map:
+  // these may exist at the top-level of a W3C credential, but should be moved inside vc when transforming to JWT
+  const additionalPropNames = ['evidence', 'termsOfUse', 'refreshService', 'credentialSchema', 'credentialStatus']
 
-  result.vc.termsOfUse = input.termsOfUse
-  if (removeOriginalFields) {
-    delete result.termsOfUse
+  for (let prop of additionalPropNames) {
+    if (input[prop]) {
+      if (!result.vc[prop]) {
+        result.vc[prop] = input[prop]
+      }
+      if (removeOriginalFields) {
+        delete result[prop]
+      }
+    }
   }
 
   return result as JwtCredentialPayload


### PR DESCRIPTION
Fixes `transformCredentialInput`:
1. when input is passed in JWT format (i.e. with a `vc` prop) existing values should not be overwritten
  input
  ```
  transformCredentialInput({ vc: { evidence: 'foo' }})
  ```
  output
  ```
  {  vc: { evidence: undefined }}
   ```
2. when fields like `evidence` or `termsOfUse` are not present they should not be added
    current output
    ```
      {
        vc: {
          '@context': [ 'https://www.w3.org/2018/credentials/v1' ],
          type: [ 'VerifiableCredential' ],
          credentialSubject: { alumniOf: [Object] },
          credentialSchema: undefined,
          evidence: undefined,
          credentialStatus: undefined,
          termsOfUse: undefined
        },
        iss: 'did:key:z6MkqR9cKxr9aq6fYb1EA6J1nWoVebGwUVHXih1EHSWNLvx1',
        sub: 'did:example:ebfeb1f712ebc6f1c276e12ec21',
        nbf: 1623814574,
        jti: 'urn:uuid:0c03da3e-350c-4572-b01e-1eaca8310b55'
      }
      ```