### PR TITLE
fix: allow credentials with an empty `credentialSubject` property

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -148,7 +148,7 @@ describe('createVerifiableCredential', () => {
     expect(mockValidateTimestamp).toHaveBeenCalledWith(verifiableCredentialPayload.nbf)
     expect(mockValidateContext).toHaveBeenCalledWith(verifiableCredentialPayload.vc['@context'])
     expect(mockValidateVcType).toHaveBeenCalledWith(verifiableCredentialPayload.vc.type)
-    expect(mockValidateCredentialSubject).toHaveBeenCalledWith(verifiableCredentialPayload.vc.credentialSubject)
+    expect(mockValidateCredentialSubject).toHaveBeenCalledWith(verifiableCredentialPayload.vc)
   })
   it('calls functions to validate optional fields if they are present', async () => {
     expect.assertions(1)

--- a/src/__tests__/validators.test.ts
+++ b/src/__tests__/validators.test.ts
@@ -81,11 +81,48 @@ describe('validators', () => {
   })
 
   describe('validateCredentialSubject', () => {
-    it('does not throw if the value is an object with at least one attribute', () => {
-      expect(() => validators.validateCredentialSubject({ name: 'test' })).not.toThrow()
+    it('does not throw if the payload contains a `credentialSubject` property', () => {
+      expect(() => validators.validateCredentialSubject({ credentialSubject: { name: 'test' } })).not.toThrow()
     })
-    it('throws a TypeError if the value is an object with no attributes', () => {
+    it('does not throw if the payload contains a `vc.credentialSubject` property', () => {
+      expect(() => validators.validateCredentialSubject({ vc: { credentialSubject: { name: 'test' } } })).not.toThrow()
+    })
+    it('does not throw if the payload contains an empty `credentialSubject` property', () => {
+      expect(() => validators.validateCredentialSubject({ credentialSubject: {} })).not.toThrow()
+    })
+    it('does not throw if the payload contains an empty `vc.credentialSubject` property', () => {
+      expect(() => validators.validateCredentialSubject({ vc: { credentialSubject: {} } })).not.toThrow()
+    })
+    it('does not throw if the value is an array of objects with at least one non-empty entry', () => {
+      expect(() => validators.validateCredentialSubject({ credentialSubject: [{ name: 'test' }] })).not.toThrow()
+    })
+    it('does not throw if the value is an array of objects with at least one entry', () => {
+      expect(() => validators.validateCredentialSubject({ credentialSubject: [{}] })).not.toThrow()
+    })
+
+    it('throws a TypeError if the credential does not have a credentialSubject property', () => {
       expect(() => validators.validateCredentialSubject({})).toThrow(TypeError)
+    })
+    it('throws a TypeError if the credential does not have a vc.credentialSubject property', () => {
+      expect(() => validators.validateCredentialSubject({})).toThrow(TypeError)
+    })
+    it('throws a TypeError if the credentialSubject is null', () => {
+      expect(() => validators.validateCredentialSubject({ credentialSubject: null })).toThrow(TypeError)
+    })
+    it('throws a TypeError if the vc.credentialSubject is null', () => {
+      expect(() => validators.validateCredentialSubject({ vc: { credentialSubject: null } })).toThrow(TypeError)
+    })
+    it('throws a TypeError if the credentialSubject is undefined', () => {
+      expect(() => validators.validateCredentialSubject({ credentialSubject: undefined })).toThrow(TypeError)
+    })
+    it('throws a TypeError if the vc.credentialSubject is undefined', () => {
+      expect(() => validators.validateCredentialSubject({ vc: { credentialSubject: undefined } })).toThrow(TypeError)
+    })
+    it('throws a TypeError if the credentialSubject is an empty array', () => {
+      expect(() => validators.validateCredentialSubject({ credentialSubject: [] })).toThrow(TypeError)
+    })
+    it('throws a TypeError if the vc.credentialSubject is an empty array', () => {
+      expect(() => validators.validateCredentialSubject({ vc: { credentialSubject: [] } })).toThrow(TypeError)
     })
   })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -140,7 +140,7 @@ export async function createVerifiablePresentationJwt(
 export function validateJwtCredentialPayload(payload: JwtCredentialPayload): void {
   validators.validateContext(payload.vc['@context'])
   validators.validateVcType(payload.vc.type)
-  validators.validateCredentialSubject(payload.vc.credentialSubject)
+  validators.validateCredentialSubject(payload.vc)
   if (payload.nbf) validators.validateTimestamp(payload.nbf)
   if (payload.exp) validators.validateTimestamp(payload.exp)
 }
@@ -148,7 +148,7 @@ export function validateJwtCredentialPayload(payload: JwtCredentialPayload): voi
 export function validateCredentialPayload(payload: CredentialPayload): void {
   validators.validateContext(payload['@context'])
   validators.validateVcType(payload.type)
-  validators.validateCredentialSubject(payload.credentialSubject)
+  validators.validateCredentialSubject(payload)
   if (payload.issuanceDate) validators.validateTimestamp(payload.issuanceDate)
   if (payload.expirationDate) validators.validateTimestamp(payload.expirationDate)
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,15 @@ export const JWT_FORMAT = /^[A-Za-z0-9-_=]+\.[A-Za-z0-9-_=]+\.?[A-Za-z0-9-_.+/=]
 export const DEFAULT_CONTEXT = 'https://www.w3.org/2018/credentials/v1'
 export const DEFAULT_VC_TYPE = 'VerifiableCredential'
 export const DEFAULT_VP_TYPE = 'VerifiablePresentation'
+
+/**
+ * This is a synthetic Proof type used when JWT credentials are expressed as JSON, after being parsed and interpreted
+ * according to the rules expressed in {@link https://w3c.github.io/vc-data-model/#jwt-encoding the data model}
+ *
+ * This synthetic proof type is only used for convenience, and credentials using this proof type MUST NOT be
+ * transmitted or interpreted directly. The actual verifiable credential string (that is signed and integrity
+ * protected) MUST be extracted from the `*.proof.jwt` property.
+ */
 export const DEFAULT_JWT_PROOF_TYPE = 'JwtProof2020'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -37,6 +46,7 @@ export interface JwtCredentialPayload {
   aud?: string | string[]
   exp?: number
   jti?: string
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [x: string]: any
 }
@@ -57,12 +67,14 @@ export interface JwtPresentationPayload {
   exp?: number
   jti?: string
   nonce?: string
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [x: string]: any
 }
 
 export type IssuerType = Extensible<{ id: string }> | string
 export type DateType = string | Date
+
 /**
  * used as input when creating Verifiable Credentials
  */
@@ -109,13 +121,15 @@ type Extensible<T> = T & { [x: string]: any }
 
 /**
  * This data type represents a parsed VerifiableCredential.
- * It is meant to be an unambiguous representation of the properties of a Credential and is usually the result of a transformation method.
+ * It is meant to be an unambiguous representation of the properties of a Credential and is usually the result of a
+ * transformation method.
  *
  * `issuer` is always an object with an `id` property and potentially other app specific issuer claims
  * `issuanceDate` is an ISO DateTime string
  * `expirationDate`, is a nullable ISO DateTime string
  *
- * Any JWT specific properties are transformed to the broader W3C variant and any app specific properties are left intact
+ * Any JWT specific properties are transformed to the broader W3C variant and any app specific properties are left
+ * intact
  */
 export type W3CCredential = Extensible<Replace<FixedCredentialPayload, NarrowCredentialDefinitions>>
 
@@ -148,15 +162,18 @@ interface NarrowPresentationDefinitions {
 
 /**
  * This data type represents a parsed Presentation payload.
- * It is meant to be an unambiguous representation of the properties of a Presentation and is usually the result of a transformation method.
+ * It is meant to be an unambiguous representation of the properties of a Presentation and is usually the result of a
+ * transformation method.
  *
  * The `verifiableCredential` array should contain parsed `Verifiable<Credential>` elements.
- * Any JWT specific properties are transformed to the broader W3C variant and any other app specific properties are left intact.
+ * Any JWT specific properties are transformed to the broader W3C variant and any other app specific properties are
+ * left intact.
  */
 export type W3CPresentation = Extensible<Replace<FixedPresentationPayload, NarrowPresentationDefinitions>>
 
 export interface Proof {
   type?: string
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [x: string]: any
 }

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -1,5 +1,12 @@
-import { DEFAULT_CONTEXT, DEFAULT_VC_TYPE, DEFAULT_VP_TYPE, JWT_FORMAT } from './types'
-import { JwtCredentialSubject, DateType } from './types'
+import {
+  CredentialPayload,
+  DateType,
+  DEFAULT_CONTEXT,
+  DEFAULT_VC_TYPE,
+  DEFAULT_VP_TYPE,
+  JWT_FORMAT,
+  JwtCredentialPayload,
+} from './types'
 import { VerifiableCredential } from '.'
 import { asArray } from './converters'
 
@@ -54,8 +61,16 @@ export function validateVpType(value: string | string[]): void {
   }
 }
 
-export function validateCredentialSubject(value: JwtCredentialSubject): void {
-  if (Object.keys(value).length === 0) {
+/**
+ * Checks that the credential payload has a `credentialSubject` property
+ *
+ * See https://www.w3.org/TR/vc-data-model/#credential-subject
+ *
+ * @param credentialPayload the credential payload
+ */
+export function validateCredentialSubject(credentialPayload: Partial<CredentialPayload | JwtCredentialPayload>): void {
+  const credentialSubject = credentialPayload?.credentialSubject || credentialPayload?.vc?.credentialSubject
+  if (!credentialSubject || (Array.isArray(credentialSubject) && credentialSubject.length == 0)) {
     throw new TypeError('credentialSubject must not be empty')
   }
 }


### PR DESCRIPTION
This fixes #106, but I believe there is an inconsistency between the spec and the VC-JWS-Test-Suite.

The VC data model [defines the credentialSubject](https://www.w3.org/TR/vc-data-model/#credential-subject) as : _a set of objects that contain one or more properties that are each related to a subject of the verifiable credential_.

This implies that the credentialSubject property must not be empty, since it has to have one or more properties.

I will raise this issue in the test suite repo.