### PR TITLE
feat: add verification policies

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   ],
   "license": "ISC",
   "dependencies": {
-    "did-jwt": "^6.2.2",
+    "did-jwt": "^6.5.0",
     "did-resolver": "^4.0.0"
   },
   "repository": {

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -356,18 +356,14 @@ describe('verifyPresentation', () => {
     const options: VerifyPresentationOptions = {
       challenge: 'TEST_CHALLENGE',
     }
-    expect(verifyPresentation(PRESENTATION_JWT, resolver, options)).rejects.toThrow(
-      'Presentation does not contain the mandatory challenge (JWT: nonce) for : TEST_CHALLENGE'
-    )
+    expect(verifyPresentation(PRESENTATION_JWT, resolver, options)).rejects.toThrow(/^auth_error:.*/)
   })
 
   it('rejects a Presentation without matching domain', () => {
     const options: VerifyPresentationOptions = {
       domain: 'TEST_DOMAIN',
     }
-    expect(verifyPresentation(PRESENTATION_JWT, resolver, options)).rejects.toThrow(
-      'Presentation does not contain the mandatory domain (JWT: aud) for : TEST_DOMAIN'
-    )
+    expect(verifyPresentation(PRESENTATION_JWT, resolver, options)).rejects.toThrow(/^auth_error:.*/)
   })
 
   it('rejects an invalid JWT', () => {
@@ -414,18 +410,14 @@ describe('verifyPresentationPayloadOptions', () => {
     const options: VerifyPresentationOptions = {
       challenge: 'TEST_CHALLENGE',
     }
-    expect(() => verifyPresentationPayloadOptions(presentationPayload, options)).toThrow(
-      'Presentation does not contain the mandatory challenge (JWT: nonce) for : TEST_CHALLENGE'
-    )
+    expect(() => verifyPresentationPayloadOptions(presentationPayload, options)).toThrow(/^auth_error:.*/)
   })
 
   it('throws if payload is missing domain', () => {
     const options: VerifyPresentationOptions = {
       domain: 'TEST_DOMAIN',
     }
-    expect(() => verifyPresentationPayloadOptions(presentationPayload, options)).toThrow(
-      'Presentation does not contain the mandatory domain (JWT: aud) for : TEST_DOMAIN'
-    )
+    expect(() => verifyPresentationPayloadOptions(presentationPayload, options)).toThrow(/^auth_error:.*/)
   })
 })
 

--- a/src/__tests__/validators.test.ts
+++ b/src/__tests__/validators.test.ts
@@ -19,10 +19,10 @@ describe('validators', () => {
       expect(() => validators.validateTimestamp(Math.floor(new Date().getTime() / 1000))).not.toThrow()
     })
     it('throws a TypeError if the value is a millisecond timestamp', () => {
-      expect(() => validators.validateTimestamp(new Date().getTime())).toThrow(TypeError)
+      expect(() => validators.validateTimestamp(new Date().getTime())).toThrow(/^schema_error:.*/)
     })
     it('throws a TypeError if the value is not an integer', () => {
-      expect(() => validators.validateTimestamp(1653060380105 / 1000)).toThrow(TypeError)
+      expect(() => validators.validateTimestamp(1653060380105 / 1000)).toThrow(/^schema_error:.*/)
     })
   })
 
@@ -34,10 +34,10 @@ describe('validators', () => {
       expect(() => validators.validateContext([DEFAULT_CONTEXT, EXTRA_CONTEXT_A, EXTRA_CONTEXT_B])).not.toThrow()
     })
     it('throws a TypeError the value contains no contexts', () => {
-      expect(() => validators.validateContext([])).toThrow(TypeError)
+      expect(() => validators.validateContext([])).toThrow(/^schema_error:.*/)
     })
     it('throws a TypeError the value is missing the default context', () => {
-      expect(() => validators.validateContext([EXTRA_CONTEXT_A, EXTRA_CONTEXT_B])).toThrow(TypeError)
+      expect(() => validators.validateContext([EXTRA_CONTEXT_A, EXTRA_CONTEXT_B])).toThrow(/^schema_error:.*/)
     })
   })
 
@@ -49,10 +49,10 @@ describe('validators', () => {
       expect(() => validators.validateVcType([DEFAULT_VC_TYPE, EXTRA_TYPE_A, EXTRA_TYPE_B])).not.toThrow()
     })
     it('throws a TypeError the value contains no types', () => {
-      expect(() => validators.validateVcType([])).toThrow(TypeError)
+      expect(() => validators.validateVcType([])).toThrow(/^schema_error:.*/)
     })
     it('throws a TypeError the value is missing the default type', () => {
-      expect(() => validators.validateVcType([EXTRA_TYPE_A, EXTRA_TYPE_B])).toThrow(TypeError)
+      expect(() => validators.validateVcType([EXTRA_TYPE_A, EXTRA_TYPE_B])).toThrow(/^schema_error:.*/)
     })
   })
 
@@ -64,10 +64,10 @@ describe('validators', () => {
       expect(() => validators.validateVpType([DEFAULT_VP_TYPE, EXTRA_TYPE_A, EXTRA_TYPE_B])).not.toThrow()
     })
     it('throws a TypeError the value contains no types', () => {
-      expect(() => validators.validateVpType([])).toThrow(TypeError)
+      expect(() => validators.validateVpType([])).toThrow(/^schema_error:.*/)
     })
     it('throws a TypeError the value is missing the default type', () => {
-      expect(() => validators.validateVpType([EXTRA_TYPE_A, EXTRA_TYPE_B])).toThrow(TypeError)
+      expect(() => validators.validateVpType([EXTRA_TYPE_A, EXTRA_TYPE_B])).toThrow(/^schema_error:.*/)
     })
   })
 
@@ -76,7 +76,7 @@ describe('validators', () => {
       expect(() => validators.validateJwtFormat(VC_JWT)).not.toThrow()
     })
     it('throws a TypeError if the value is not a valid JWT format', () => {
-      expect(() => validators.validateJwtFormat('not a jwt')).toThrow(TypeError)
+      expect(() => validators.validateJwtFormat('not a jwt')).toThrow(/^format_error:.*/)
     })
   })
 
@@ -85,7 +85,7 @@ describe('validators', () => {
       expect(() => validators.validateCredentialSubject({ name: 'test' })).not.toThrow()
     })
     it('throws a TypeError if the value is an object with no attributes', () => {
-      expect(() => validators.validateCredentialSubject({})).toThrow(TypeError)
+      expect(() => validators.validateCredentialSubject({})).toThrow(/^schema_error:.*/)
     })
   })
 })

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,28 @@
+import { JWT_ERROR } from 'did-jwt'
+
+/**
+ * Error prefixes used for known verification failure cases related to the
+ * {@link https://www.w3.org/TR/vc-data-model/ | Verifiable Credential data model }
+ */
+export const enum VC_ERROR {
+  /**
+   * Thrown when the credential or presentation being verified does not conform to the data model defined by
+   * {@link https://www.w3.org/TR/vc-data-model/ | the spec}
+   */
+  SCHEMA_ERROR = 'schema_error',
+
+  /**
+   * Thrown when the input is not a JWT string
+   */
+  FORMAT_ERROR = 'format_error',
+
+  /**
+   * Thrown when verifying a presentation where `challenge` and/or `domain` don't match the expected values.
+   */
+  AUTH_ERROR = 'auth_error',
+}
+
+/**
+ * Known validation or verification error prefixes.
+ */
+export type VC_JWT_ERROR = VC_ERROR | JWT_ERROR

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { Signer, JWTVerified, JWTHeader, JWTOptions } from 'did-jwt'
+import { Signer, JWTVerified, JWTHeader, JWTOptions, JWTVerifyOptions } from 'did-jwt'
 
 export const JWT_ALG = 'ES256K'
 export const DID_FORMAT = /^did:([a-zA-Z0-9_]+):([:[a-zA-Z0-9_.-]+)(\/[^#]*)?(#.*)?$/
@@ -37,6 +37,7 @@ export interface JwtCredentialPayload {
   aud?: string | string[]
   exp?: number
   jti?: string
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [x: string]: any
 }
@@ -57,12 +58,14 @@ export interface JwtPresentationPayload {
   exp?: number
   jti?: string
   nonce?: string
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [x: string]: any
 }
 
 export type IssuerType = Extensible<{ id: string }> | string
 export type DateType = string | Date
+
 /**
  * used as input when creating Verifiable Credentials
  */
@@ -109,13 +112,15 @@ type Extensible<T> = T & { [x: string]: any }
 
 /**
  * This data type represents a parsed VerifiableCredential.
- * It is meant to be an unambiguous representation of the properties of a Credential and is usually the result of a transformation method.
+ * It is meant to be an unambiguous representation of the properties of a Credential and is usually the result of a
+ * transformation method.
  *
  * `issuer` is always an object with an `id` property and potentially other app specific issuer claims
  * `issuanceDate` is an ISO DateTime string
  * `expirationDate`, is a nullable ISO DateTime string
  *
- * Any JWT specific properties are transformed to the broader W3C variant and any app specific properties are left intact
+ * Any JWT specific properties are transformed to the broader W3C variant and any app specific properties are left
+ * intact
  */
 export type W3CCredential = Extensible<Replace<FixedCredentialPayload, NarrowCredentialDefinitions>>
 
@@ -148,15 +153,18 @@ interface NarrowPresentationDefinitions {
 
 /**
  * This data type represents a parsed Presentation payload.
- * It is meant to be an unambiguous representation of the properties of a Presentation and is usually the result of a transformation method.
+ * It is meant to be an unambiguous representation of the properties of a Presentation and is usually the result of a
+ * transformation method.
  *
  * The `verifiableCredential` array should contain parsed `Verifiable<Credential>` elements.
- * Any JWT specific properties are transformed to the broader W3C variant and any other app specific properties are left intact.
+ * Any JWT specific properties are transformed to the broader W3C variant and any other app specific properties are
+ * left intact.
  */
 export type W3CPresentation = Extensible<Replace<FixedPresentationPayload, NarrowPresentationDefinitions>>
 
 export interface Proof {
   type?: string
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [x: string]: any
 }
@@ -242,7 +250,38 @@ export interface CreateCredentialOptions extends Partial<JWTOptions> {
  * These options are forwarded to the lower level verification code
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type VerifyCredentialOptions = Record<string, any>
+export interface VerifyCredentialOptions extends JWTVerifyOptions {
+  /**
+   * When transforming the result of the verification into a W3C VerifiableCredential, this property dictates whether
+   * the JWT specific properties are removed from the payload or not. Defaults to `true`.
+   */
+  removeOriginalFields?: boolean
+
+  /**
+   * Use this to override the default checks performed during verification
+   */
+  policies?: VerifyCredentialPolicies
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [x: string]: any
+}
+
+export interface VerifyCredentialPolicies {
+  // tweak the time at which the credential should be valid (UNIX timestamp, in seconds)
+  now?: number
+  // when false skips issuanceDate check
+  issuanceDate?: boolean
+  // when false skips expirationDate check
+  expirationDate?: boolean
+  // when false skips format checks
+  format?: boolean
+
+  /**
+   * Other policies are forwarded to lower level libs
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [x: string]: any
+}
 
 /**
  * Represents the Verification Options that can be passed to the verifyPresentation method.

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -2,6 +2,7 @@ import { DEFAULT_CONTEXT, DEFAULT_VC_TYPE, DEFAULT_VP_TYPE, JWT_FORMAT } from '.
 import { JwtCredentialSubject, DateType } from './types'
 import { VerifiableCredential } from '.'
 import { asArray } from './converters'
+import { VC_ERROR } from './errors'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function isDateObject(input: any): input is Date {
@@ -10,7 +11,7 @@ function isDateObject(input: any): input is Date {
 
 export function validateJwtFormat(value: VerifiableCredential): void {
   if (typeof value === 'string' && !value.match(JWT_FORMAT)) {
-    throw new TypeError(`"${value}" is not a valid JWT format`)
+    throw new TypeError(`${VC_ERROR.FORMAT_ERROR}: "${value}" is not a valid JWT format`)
   }
 }
 
@@ -24,38 +25,38 @@ export function validateJwtFormat(value: VerifiableCredential): void {
 export function validateTimestamp(value: number | DateType): void {
   if (typeof value === 'number') {
     if (!(Number.isInteger(value) && value < 100000000000)) {
-      throw new TypeError(`"${value}" is not a unix timestamp in seconds`)
+      throw new TypeError(`${VC_ERROR.SCHEMA_ERROR}: "${value}" is not a unix timestamp in seconds`)
     }
   } else if (typeof value === 'string') {
     validateTimestamp(Math.floor(new Date(value).valueOf() / 1000))
   } else if (!isDateObject(value)) {
-    throw new TypeError(`"${value}" is not a valid time`)
+    throw new TypeError(`${VC_ERROR.SCHEMA_ERROR}: "${value}" is not a valid time`)
   }
 }
 
 export function validateContext(value: string | string[]): void {
   const input = asArray(value)
   if (input.length < 1 || input.indexOf(DEFAULT_CONTEXT) === -1) {
-    throw new TypeError(`@context is missing default context "${DEFAULT_CONTEXT}"`)
+    throw new TypeError(`${VC_ERROR.SCHEMA_ERROR}: @context is missing default context "${DEFAULT_CONTEXT}"`)
   }
 }
 
 export function validateVcType(value: string | string[]): void {
   const input = asArray(value)
   if (input.length < 1 || input.indexOf(DEFAULT_VC_TYPE) === -1) {
-    throw new TypeError(`type is missing default "${DEFAULT_VC_TYPE}"`)
+    throw new TypeError(`${VC_ERROR.SCHEMA_ERROR}: type is missing default "${DEFAULT_VC_TYPE}"`)
   }
 }
 
 export function validateVpType(value: string | string[]): void {
   const input = asArray(value)
   if (input.length < 1 || input.indexOf(DEFAULT_VP_TYPE) === -1) {
-    throw new TypeError(`type is missing default "${DEFAULT_VP_TYPE}"`)
+    throw new TypeError(`${VC_ERROR.SCHEMA_ERROR}: type is missing default "${DEFAULT_VP_TYPE}"`)
   }
 }
 
 export function validateCredentialSubject(value: JwtCredentialSubject): void {
   if (Object.keys(value).length === 0) {
-    throw new TypeError('credentialSubject must not be empty')
+    throw new TypeError(`${VC_ERROR.SCHEMA_ERROR}: credentialSubject must not be empty`)
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4440,10 +4440,10 @@ did-jwt@^6.1.2:
     multiformats "^9.6.5"
     uint8arrays "^3.0.0"
 
-did-jwt@^6.2.2:
-  version "6.2.2"
-  resolved "https://registry.yarnpkg.com/did-jwt/-/did-jwt-6.2.2.tgz#6a3e84bb0d75dee510ba2481f31b9c1530a41cc8"
-  integrity sha512-/OJBpNkNIUGZW5L5GzuSivpB+RvRhOdRKMQ9a3KAzyTNI85RUoxelqYDwmUOA6i+MKVeJQaONf4beT03ACgQ/w==
+did-jwt@^6.5.0:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/did-jwt/-/did-jwt-6.5.0.tgz#0179ed25db32c111a667563c0d7b54e5d6ecb939"
+  integrity sha512-yfdqk2N6+161Yeay4HMC5daic/HRIsc+W1r7JQlNtL14fmQyaPgJxnxpXdc7Qmwd+pMlfpi1oOEtraExDE6MzQ==
   dependencies:
     "@stablelib/ed25519" "^1.0.2"
     "@stablelib/random" "^1.0.1"


### PR DESCRIPTION
closes #118

This adds the ability to specify verification policies that can override certain checks that are performed besides the JWT signatures during verification.

Now one can skip timestamp checks (by setting `issuanceDate` and `expirationDate` to `false` as a policy), or check that a credential was valid at a different moment in time (by specifying a different `now` as a policy), or skip format checks in case you are dealing with legacy data-model (by setting `format` to `false` in the policy).

Verification options, including policies are also forwarded to `did-jwt`, so you can also provide JWT specific overrides if needed.

Also part of this PR is a change to the error messages. All known validation errors are now prefixed with recognizable codes, which are also exported along with the codes from `did-jwt` as the `VC_JWT_ERROR` type.
Wen a VC/VP does not verify, these error message prefixes can be used to distinguish between known verification errors (signature, timestamp, data-model, audience, auth) and exceptional situations which don't represent the real-world validity of a VC/VP.

BREAKING CHANGE: The error messages are now prefixed with recognizable error codes. This is a breaking change if you were checking the exact error messages being returned before. Otherwise, it is safe to upgrade without issues.