### PR TITLE
feat: export VC_JWT_ERROR as plain object

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   ],
   "license": "ISC",
   "dependencies": {
-    "did-jwt": "^6.5.0",
+    "did-jwt": "^6.6.0",
     "did-resolver": "^4.0.0"
   },
   "repository": {

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -8,28 +8,28 @@ import { JWT_ERROR } from 'did-jwt'
  * Error prefixes used for known verification failure cases related to the
  * {@link https://www.w3.org/TR/vc-data-model/ | Verifiable Credential data model }
  */
-export const enum VC_ERROR {
+export const VC_ERROR = {
   /**
    * Thrown when the credential or presentation being verified does not conform to the data model defined by
    * {@link https://www.w3.org/TR/vc-data-model/ | the spec}
    */
-  SCHEMA_ERROR = 'schema_error',
+  SCHEMA_ERROR: 'schema_error',
 
   /**
    * Thrown when the input is not a JWT string
    */
-  FORMAT_ERROR = 'format_error',
+  FORMAT_ERROR: 'format_error',
 
   /**
    * Thrown when verifying a presentation where `challenge` and/or `domain` don't match the expected values.
    */
-  AUTH_ERROR = 'auth_error',
+  AUTH_ERROR: 'auth_error',
 }
 
 /**
  * Known validation or verification error prefixes.
  */
-export type VC_JWT_ERROR = VC_ERROR | JWT_ERROR
+export const VC_JWT_ERROR = { ...VC_ERROR, ...JWT_ERROR }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function isDateObject(input: any): input is Date {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4440,10 +4440,10 @@ did-jwt@^6.1.2:
     multiformats "^9.6.5"
     uint8arrays "^3.0.0"
 
-did-jwt@^6.5.0:
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/did-jwt/-/did-jwt-6.5.0.tgz#0179ed25db32c111a667563c0d7b54e5d6ecb939"
-  integrity sha512-yfdqk2N6+161Yeay4HMC5daic/HRIsc+W1r7JQlNtL14fmQyaPgJxnxpXdc7Qmwd+pMlfpi1oOEtraExDE6MzQ==
+did-jwt@^6.6.0:
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/did-jwt/-/did-jwt-6.6.0.tgz#e7c932f7e3ff992b15aef7db3d530c81fb34902d"
+  integrity sha512-qSjXEEHS4fSbBHRCC/ObDzPVkCVvuXIfIiGWa03HNRr85gGkbxzBrxUsUbXfXo1CuzeCqmmZpK4nM4VWlZh6bQ==
   dependencies:
     "@stablelib/ed25519" "^1.0.2"
     "@stablelib/random" "^1.0.1"


### PR DESCRIPTION
closes #120

This also bumps did-jwt dependency to 6.6.0 so that the JWT_ERROR can be imported from there and extended to form the VC_JWT_ERROR prefix mapping.

This is technically a breaking change, but I assume there hasn't been enough time for the original enum to be adopted.

