### PR TITLE
fix(deps): bump did-jwt to v6.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   ],
   "license": "ISC",
   "dependencies": {
-    "did-jwt": "^6.6.0",
+    "did-jwt": "^6.11.0",
     "did-resolver": "^4.0.0"
   },
   "repository": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4440,10 +4440,10 @@ did-jwt@^6.1.2:
     multiformats "^9.6.5"
     uint8arrays "^3.0.0"
 
-did-jwt@^6.6.0:
-  version "6.6.0"
-  resolved "https://registry.yarnpkg.com/did-jwt/-/did-jwt-6.6.0.tgz#e7c932f7e3ff992b15aef7db3d530c81fb34902d"
-  integrity sha512-qSjXEEHS4fSbBHRCC/ObDzPVkCVvuXIfIiGWa03HNRr85gGkbxzBrxUsUbXfXo1CuzeCqmmZpK4nM4VWlZh6bQ==
+did-jwt@^6.11.0:
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/did-jwt/-/did-jwt-6.11.0.tgz#19191a2a0c8bd513d6383afe94456ae84e0fa5bd"
+  integrity sha512-/qyYzo8v/xjwyt5x3tbknjQ2L15J1JzB+0cQK5/2SgnoOoclOmtEgZoRaxG1B73VMOgyZQYLBytRT4COUVhcpw==
   dependencies:
     "@stablelib/ed25519" "^1.0.2"
     "@stablelib/random" "^1.0.1"


### PR DESCRIPTION
In this [commit](https://github.com/decentralized-identity/did-jwt/commit/f9f1aebb33ef8adfe2200a5d0e365a0c12042098), did-jwt was fixed so that ES256K can be used with JsonWebKey2020, so please increase the version