### PR TITLE
fix(deps): Update dependency did-jwt to v8

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   ],
   "license": "ISC",
   "dependencies": {
-    "did-jwt": "^7.4.5",
+    "did-jwt": "^8.0.0",
     "did-resolver": "^4.1.0"
   },
   "repository": {
@@ -60,7 +60,7 @@
     "eslint-config-prettier": "9.0.0",
     "eslint-plugin-jest": "27.6.0",
     "eslint-plugin-prettier": "5.0.1",
-    "ethr-did": "3.0.4",
+    "ethr-did": "3.0.13",
     "faker": "6.6.6",
     "jest": "29.7.0",
     "microbundle": "0.15.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,11 +12,6 @@
   resolved "https://registry.yarnpkg.com/@adraffy/ens-normalize/-/ens-normalize-1.10.0.tgz#d2a39395c587e092d77cbbc80acf956a54f38bf7"
   integrity sha512-nA9XHtlAkYfJxY7bce8DcN7eKxWWCWkU+1GR9d+U6MbNpfwQp8TI7vqOsBsMcHoT4mBu2kypKoSKnghEzOOq5Q==
 
-"@adraffy/ens-normalize@1.9.2":
-  version "1.9.2"
-  resolved "https://registry.yarnpkg.com/@adraffy/ens-normalize/-/ens-normalize-1.9.2.tgz#60111a5d9db45b2e5cbb6231b0bb8d97e8659316"
-  integrity sha512-0h+FrQDqe2Wn+IIGFkTCd4aAwTJ+7834Ek1COohCyV26AXhwQ7WQaz+4F/nLOeVl/3BtWHOHLPsq46V8YB46Eg==
-
 "@ampproject/remapping@^2.1.0":
   version "2.2.0"
   resolved "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz"
@@ -2530,11 +2525,6 @@
   dependencies:
     "@noble/hashes" "1.3.3"
 
-"@noble/hashes@1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.1.2.tgz#e9e035b9b166ca0af657a7848eb2718f0f22f183"
-  integrity sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==
-
 "@noble/hashes@1.3.2":
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.2.tgz#6f26dbc8fbc7205873ce3cee2f690eba0d421b39"
@@ -2544,11 +2534,6 @@
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.3.tgz#39908da56a4adc270147bb07968bf3b16cfe1699"
   integrity sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==
-
-"@noble/secp256k1@1.7.1":
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/@noble/secp256k1/-/secp256k1-1.7.1.tgz#b251c70f824ce3ca7f8dc3df08d58f005cc0507c"
-  integrity sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -4570,24 +4555,10 @@ detect-newline@^3.0.0:
   resolved "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
-did-jwt@^7.2.0:
-  version "7.4.4"
-  resolved "https://registry.yarnpkg.com/did-jwt/-/did-jwt-7.4.4.tgz#0d925bd453c5b18001ba247890b173778120c74c"
-  integrity sha512-OW9CwDvHx0E2qjrRfy8wm5sJekXxJqGrAZXgdfhYpHEHX31Kn7Cz9gShrpGlIqYFsEsEAsA5xhFIidKAawyNCg==
-  dependencies:
-    "@noble/ciphers" "^0.4.0"
-    "@noble/curves" "^1.0.0"
-    "@noble/hashes" "^1.3.0"
-    "@scure/base" "^1.1.3"
-    canonicalize "^2.0.0"
-    did-resolver "^4.1.0"
-    multiformats "^12.0.0"
-    uint8arrays "^4.0.3"
-
-did-jwt@^7.4.5:
-  version "7.4.6"
-  resolved "https://registry.yarnpkg.com/did-jwt/-/did-jwt-7.4.6.tgz#7196b31c35a8d613ed59d18cc0ae697b30a3e093"
-  integrity sha512-+EIGBlngr2fwaDQoOyxgVqms+JfRyxI0u9Zv6+/YQ/cVoDcLtF1W9cVEUx/P+NVmCWifeNq34EClrcDnv8z2Qw==
+did-jwt@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/did-jwt/-/did-jwt-8.0.0.tgz#9a1fdb81368cbf3a34985bc73dc1b21ac6b0e74c"
+  integrity sha512-lJSVC9Ckxl+U+jDPbdATDtXV7CwE0XGT0Js6KNfjRlaj0LTXvDF90IAyayFwLUzO6punA/q3ZHVfTZaYDhHrLw==
   dependencies:
     "@noble/ciphers" "^0.4.0"
     "@noble/curves" "^1.0.0"
@@ -4599,7 +4570,7 @@ did-jwt@^7.4.5:
     multiformats "^9.6.2"
     uint8arrays "3.1.1"
 
-did-resolver@^4.0.1, did-resolver@^4.1.0:
+did-resolver@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/did-resolver/-/did-resolver-4.1.0.tgz#740852083c4fd5bf9729d528eca5d105aff45eb6"
   integrity sha512-S6fWHvCXkZg2IhS4RcVHxwuyVejPR7c+a4Go0xbQ9ps5kILa8viiYQgrM4gfTyeTjJ0ekgJH9gk/BawTpmkbZA==
@@ -5027,23 +4998,10 @@ esutils@^2.0.2:
   resolved "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
-ethers@6.7.1:
-  version "6.7.1"
-  resolved "https://registry.yarnpkg.com/ethers/-/ethers-6.7.1.tgz#9c65e8b5d8e9ad77b7e8cf1c46099892cfafad49"
-  integrity sha512-qX5kxIFMfg1i+epfgb0xF4WM7IqapIIu50pOJ17aebkxxa4BacW5jFrQRmCJpDEg2ZK2oNtR5QjrQ1WDBF29dA==
-  dependencies:
-    "@adraffy/ens-normalize" "1.9.2"
-    "@noble/hashes" "1.1.2"
-    "@noble/secp256k1" "1.7.1"
-    "@types/node" "18.15.13"
-    aes-js "4.0.0-beta.5"
-    tslib "2.4.0"
-    ws "8.5.0"
-
-ethers@^6.7.1:
-  version "6.8.0"
-  resolved "https://registry.yarnpkg.com/ethers/-/ethers-6.8.0.tgz#0a26f57e96fd697cefcfcef464e0c325689d1daf"
-  integrity sha512-zrFbmQRlraM+cU5mE4CZTLBurZTs2gdp2ld0nG/f3ecBK+x6lZ69KSxBqZ4NjclxwfTxl5LeNufcBbMsTdY53Q==
+ethers@^6.8.1:
+  version "6.10.0"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-6.10.0.tgz#20f3c63c60d59a993f8090ad423d8a3854b3b1cd"
+  integrity sha512-nMNwYHzs6V1FR3Y4cdfxSQmNgZsRj1RiTU25JwvnJLmyzw9z3SKxNc2XKDuiXXo/v9ds5Mp9m6HBabgYQQ26tA==
   dependencies:
     "@adraffy/ens-normalize" "1.10.0"
     "@noble/curves" "1.2.0"
@@ -5053,23 +5011,23 @@ ethers@^6.7.1:
     tslib "2.4.0"
     ws "8.5.0"
 
-ethr-did-resolver@9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/ethr-did-resolver/-/ethr-did-resolver-9.0.0.tgz#3d453e8c03e41c7287c3458cd70ebaf15c664823"
-  integrity sha512-L+c3NZk4fEC+jB1WWPtlUVPZk0r1XItxP54oRLhYpRMRwpG7lPnCzKV6XjuiCTDI7bJEfzrAYYn9sbxbIwEtLA==
+ethr-did-resolver@10.1.3:
+  version "10.1.3"
+  resolved "https://registry.yarnpkg.com/ethr-did-resolver/-/ethr-did-resolver-10.1.3.tgz#c221ea30c602cb391e1b6e3b51aa6f4bdd1dc1d4"
+  integrity sha512-JQuZwvKqdo4waiFo4CcjaDZ3iFMh/FRFR/wDHiqUF4MfziMxSx35L22ESoSEsuyweP30g/6bVHv6nlRW5zUg3w==
   dependencies:
-    did-resolver "^4.0.1"
-    ethers "6.7.1"
-
-ethr-did@3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/ethr-did/-/ethr-did-3.0.4.tgz#3bd5cf7600dc34c4314e59988a8d061f354c9f31"
-  integrity sha512-QDBNVCTfbz2wvjorOvcrO9gFUomTTmrFg9IryEoszUrt/LZ9i4WXpCB5j8r1JWUzXJgBz7o4ckzBgkjgozrnbw==
-  dependencies:
-    did-jwt "^7.2.0"
     did-resolver "^4.1.0"
-    ethers "^6.7.1"
-    ethr-did-resolver "9.0.0"
+    ethers "^6.8.1"
+
+ethr-did@3.0.13:
+  version "3.0.13"
+  resolved "https://registry.yarnpkg.com/ethr-did/-/ethr-did-3.0.13.tgz#3309eebb3d9c0424a380eb50144cf29f053ed11b"
+  integrity sha512-eHOJSxM3CPvGc9EBcJo7wzI38WzNu0MinwJdwooDsqnetWdhxtM6trHJDl7ZsLOI1WW0qyrVwEe99uXusSy+oA==
+  dependencies:
+    did-jwt "^8.0.0"
+    did-resolver "^4.1.0"
+    ethers "^6.8.1"
+    ethr-did-resolver "10.1.3"
 
 event-target-shim@^5.0.0:
   version "5.0.1"
@@ -7385,11 +7343,6 @@ multibase@^4.0.6:
   dependencies:
     "@multiformats/base-x" "^4.0.1"
 
-multiformats@^12.0.0, multiformats@^12.0.1:
-  version "12.1.3"
-  resolved "https://registry.yarnpkg.com/multiformats/-/multiformats-12.1.3.tgz#cbf7a9861e11e74f8228b21376088cb43ba8754e"
-  integrity sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==
-
 multiformats@^9.4.2, multiformats@^9.6.2:
   version "9.9.0"
   resolved "https://registry.yarnpkg.com/multiformats/-/multiformats-9.9.0.tgz#c68354e7d21037a8f1f8833c8ccd68618e8f1d37"
@@ -9679,13 +9632,6 @@ uint8arrays@3.1.1:
   integrity sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==
   dependencies:
     multiformats "^9.4.2"
-
-uint8arrays@^4.0.3:
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/uint8arrays/-/uint8arrays-4.0.6.tgz#bae68b536c2e87147045b95d73d29e503e45ecab"
-  integrity sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==
-  dependencies:
-    multiformats "^12.0.1"
 
 unbox-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
BREAKING CHANGE: the updated `did-jwt` library includes some breaking changes so we are bumping the major version here too for safety